### PR TITLE
fix: docker push

### DIFF
--- a/.github/workflows/docker-monitor.yml
+++ b/.github/workflows/docker-monitor.yml
@@ -26,3 +26,5 @@ jobs:
           tags: |
             lcnem/telescope-monitor:${{ steps.variables.outputs.version }}
             lcnem/telescope-monitor:latest
+        env:
+          GO111MODULE: auto


### PR DESCRIPTION
CDの修正のため
Push to Docker Hubの際に環境変数を渡すことで`go install . `を通るようにしたい。