### PR TITLE
fix: key select related service and guard

### DIFF
--- a/projects/main/src/app/models/keys/key-select.guard.ts
+++ b/projects/main/src/app/models/keys/key-select.guard.ts
@@ -28,8 +28,15 @@ export class KeySelectGuard implements CanActivate {
       .pipe(first())
       .toPromise()
       .then(async (currentKey) => {
+        currentKey = await this.keySelectDialog.open();
+
+        let count = 0
         while (!currentKey) {
+          if (count > 0) {
+            return false;
+          }
           currentKey = await this.keySelectDialog.open();
+          count++
         }
 
         return true;

--- a/projects/main/src/app/models/keys/key.infrastructure.service.ts
+++ b/projects/main/src/app/models/keys/key.infrastructure.service.ts
@@ -74,11 +74,16 @@ export class KeyInfrastructureService implements IKeyInfrastructure {
    * Get all from Indexed DB
    */
   async list(): Promise<Key[]> {
-    return (await this.db.table('keys').toArray()).map((data) => ({
-      id: data.id,
-      type: data.type,
-      public_key: data.public_key,
-    }));
+    try {
+      return (await this.db.table('keys').toArray()).map((data) => ({
+        id: data.id,
+        type: data.type,
+        public_key: data.public_key,
+      }));
+    } catch (error) {
+      console.error(error);
+      return []
+    }
   }
 
   /**
@@ -91,7 +96,8 @@ export class KeyInfrastructureService implements IKeyInfrastructure {
   async set(id: string, type: KeyType, privateKey: string) {
     const key = await this.get(id);
     if (key !== undefined) {
-      throw new Error('Already exists');
+      console.log('Already exists');
+      return;
     }
 
     const privKey = this.getPrivKey(type, privateKey);
@@ -102,7 +108,13 @@ export class KeyInfrastructureService implements IKeyInfrastructure {
       type,
       public_key: publicKey,
     };
-    await this.db.table('keys').put(data);
+    try {
+      await this.db.table('keys').put(data);
+      return;
+    } catch (error) {
+      console.error(error);
+      throw new Error('Failed to put key data!');
+    }
   }
 
   /**
@@ -111,6 +123,11 @@ export class KeyInfrastructureService implements IKeyInfrastructure {
    * @param id
    */
   async delete(id: string) {
-    await this.db.table('keys').where('id').equals(id).delete();
+    try {
+      await this.db.table('keys').where('id').equals(id).delete();
+    } catch (error) {
+      console.error(error);
+      throw new Error('Failed to delete key with id!');
+    }
   }
 }


### PR DESCRIPTION
close #149 
close #150 

@KimuraYu45z cc: @Senna46 @taro04 
レビューお願いします。

Key 選択関連の以下の2個の問題の解決を意図したプルリクです。

1. (bank send等で、)Key Select Dialogで選択したKeyが反映されていない問題
2. (別のページに移動しても)Key Select Dialogが無限に表示され続けるか、Key Select Dialogが一度しか表示されず一度選択するとGUIから別のKeyを選択するすべが無い状況かの2択で、これまで後者の状況に修正していた問題

botany側でcdp関連のデバッグを進めるにも、こちらが正常に動作している必要があり、先にこちらを修正する必要があるという状況で、IndexedDBへの値の読み書きや削除等のエラーハンドリングの修正や、key-select-guardでKeySelectDialogの表示回数に制限をつける等の修正を加えて、解決できたと思うという状況です。