### PR TITLE
feat: add script to deploy monitor

### DIFF
--- a/projects/monitor/deploy.sh
+++ b/projects/monitor/deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+cd ~/monitor
+docker-compose down
+docker pull lcnem/telescope-monitor:latest
+# curl -L https://raw.githubusercontent.com/lcnem/telescope/main/projects/monitor/config.json -o config.json
+# vi config.json
+curl -O https://raw.githubusercontent.com/lcnem/telescope/main/projects/monitor/docker-compose.yml
+docker-compose up -d


### PR DESCRIPTION
@KimuraYu45z cc: @Senna46 @taro04 
レビューお願いします。
monitorのデプロイ用のスクリプトを追加しました。
秘密情報を含むconfig.jsonはあらかじめサーバー上に準備しておいて、デプロイ時は `bash deploy.sh` を実行すればOKという想定のスクリプトです。