### PR TITLE
feat: add message for empty account

### DIFF
--- a/projects/main/src/app/views/accounts/account/account.component.html
+++ b/projects/main/src/app/views/accounts/account/account.component.html
@@ -1,35 +1,43 @@
 <h2>Account Info</h2>
-<mat-card *ngIf="baseAccount">
-  <mat-list>
-    <mat-list-item>
-      <span class="column-name">Sequence:</span>
-      <span class="flex-auto"></span>
-      <span class="column-value">{{ baseAccount?.sequence }}</span>
-    </mat-list-item>
-    <mat-divider [inset]="true"></mat-divider>
+<ng-container *ngIf="baseAccount === undefined || null ; then empty; else exist"></ng-container>
 
-    <mat-list-item>
-      <span class="column-name">Account Number: </span>
-      <span class="flex-auto"></span>
-      <span class="column-value">{{ baseAccount?.account_number }}</span>
-    </mat-list-item>
-    <mat-divider [inset]="true"></mat-divider>
+<ng-template #empty>
+  <p>*This account dose not have any denoms</p>
+</ng-template>
 
-    <mat-list-item>
-      <span class="column-name">Address: </span>
-      <span class="flex-auto"></span>
-      <span class="column-value">{{ baseAccount?.address }}</span>
-    </mat-list-item>
-    <mat-divider [inset]="true"></mat-divider>
+<ng-template #exist>
+  <mat-card *ngIf="baseAccount">
+    <mat-list>
+      <mat-list-item>
+        <span class="column-name">Sequence:</span>
+        <span class="flex-auto"></span>
+        <span class="column-value">{{ baseAccount?.sequence }}</span>
+      </mat-list-item>
+      <mat-divider [inset]="true"></mat-divider>
 
-    <mat-list-item>
-      <span class="column-name">Public key: </span>
-      <span class="flex-auto"></span>
-      <span class="column-value">{{ publicKey }}</span>
-    </mat-list-item>
-    <mat-divider [inset]="true"></mat-divider>
-  </mat-list>
-</mat-card>
+      <mat-list-item>
+        <span class="column-name">Account Number: </span>
+        <span class="flex-auto"></span>
+        <span class="column-value">{{ baseAccount?.account_number }}</span>
+      </mat-list-item>
+      <mat-divider [inset]="true"></mat-divider>
+
+      <mat-list-item>
+        <span class="column-name">Address: </span>
+        <span class="flex-auto"></span>
+        <span class="column-value">{{ baseAccount?.address }}</span>
+      </mat-list-item>
+      <mat-divider [inset]="true"></mat-divider>
+
+      <mat-list-item>
+        <span class="column-name">Public key: </span>
+        <span class="flex-auto"></span>
+        <span class="column-value">{{ publicKey }}</span>
+      </mat-list-item>
+      <mat-divider [inset]="true"></mat-divider>
+    </mat-list>
+  </mat-card>
+</ng-template>
 
 <h2>Coins</h2>
 <mat-card>

--- a/projects/main/src/app/views/accounts/account/distribution/distribution.component.html
+++ b/projects/main/src/app/views/accounts/account/distribution/distribution.component.html
@@ -1,4 +1,13 @@
 <h2>Validator Rewards</h2>
+
+<ng-container *ngIf="commision?.commission?.commission === undefined || []; then empty; else exist">
+</ng-container>
+<ng-template #empty>
+  <p>*This account dose not have commision</p>
+</ng-template>
+<ng-template #exist>
+</ng-template>
+
 <h3>Accumulated Commission</h3>
 <mat-card>
   <mat-list *ngFor="let com of commision?.commission?.commission">
@@ -11,6 +20,14 @@
   </mat-list>
 </mat-card>
 
+<ng-container *ngIf="rewards?.rewards?.rewards === undefined || null || []; then empty_rewards; else exist_rewards">
+</ng-container>
+<ng-template #empty_rewards>
+  <p>*This account dose not have any rewards</p>
+</ng-template>
+<ng-template #exist_rewards>
+</ng-template>
+
 <h3>Outstanding Rewards</h3>
 <mat-card>
   <mat-list *ngFor="let reward of rewards?.rewards?.rewards">
@@ -22,6 +39,14 @@
     <mat-divider [inset]="true"></mat-divider>
   </mat-list>
 </mat-card>
+
+<ng-container *ngIf="slashes?.slashes === undefined || null || []; then empty_slash; else exist_slash">
+</ng-container>
+<ng-template #empty_slash>
+  <p>*This account dose not have any slashes</p>
+</ng-template>
+<ng-template #exist_slash>
+</ng-template>
 
 <h3>Slashing</h3>
 <mat-card>

--- a/projects/main/src/app/views/accounts/account/staking/staking.component.html
+++ b/projects/main/src/app/views/accounts/account/staking/staking.component.html
@@ -1,4 +1,13 @@
 <h2>Delegator Rewards</h2>
+
+<ng-container *ngIf="totalrewards?.total === undefined || []; then empty_ttl; else exist_ttl">
+</ng-container>
+<ng-template #empty_ttl>
+  <p>*This account dose not have any rewards</p>
+</ng-template>
+<ng-template #exist_ttl>
+</ng-template>
+
 <h3>Total Rewards</h3>
 <mat-card>
   <mat-list *ngFor="let ttl of totalrewards?.total">
@@ -10,6 +19,14 @@
     <mat-divider [inset]="true"></mat-divider>
   </mat-list>
 </mat-card>
+
+<ng-container *ngIf="totalrewards?.rewards === undefined || null || []; then empty_rev; else exist_rev">
+</ng-container>
+<ng-template #empty_rev>
+  <p>*This account dose not have any rewards from validator</p>
+</ng-template>
+<ng-template #exist_rev>
+</ng-template>
 
 <h3>Rewards by Each Validator</h3>
 <!--


### PR DESCRIPTION
/accounts/:address ページにアドレス情報表示追加、表示情報が無い場合その旨メッセージ追記修正です。
[https://github.com/lcnem/telescope/issues/132](https://github.com/lcnem/telescope/issues/132)
作業途中ですが、方向性の確認含めPR作成します。