### PR TITLE
feat: add key backup dialog

### DIFF
--- a/projects/main/src/app/app.module.ts
+++ b/projects/main/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { reducers, metaReducers } from './reducers';
 import { KeySelectDialogModule } from './views/keys/key-select-dialog/key-select-dialog.module';
+import { KeyBackupDialogModule } from './views/keys/key-backup-dialog/key-backup-dialog.module';
 import { ToolbarModule } from './views/toolbar/toolbar.module';
 import { ViewModule } from './views/view.module';
 import { HttpClientModule } from '@angular/common/http';
@@ -32,6 +33,7 @@ import { LoadingDialogModule } from 'ng-loading-dialog';
     ToolbarModule,
     HttpClientModule,
     KeySelectDialogModule,
+    KeyBackupDialogModule,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/projects/main/src/app/models/keys/key-backup-dialog.service.ts
+++ b/projects/main/src/app/models/keys/key-backup-dialog.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { KeyBackupDialogComponent } from '../../views/keys/key-backup-dialog/key-backup-dialog.component';
-
+import { KeyCreateResult } from './key.model';
 
 @Injectable({
   providedIn: 'root'
@@ -13,11 +13,11 @@ export class KeyBackupDialogService {
     private readonly dialog: MatDialog,
   ) { }
 
-  async open(mnemonic: string, privatekey: string): Promise<boolean | undefined> {
+  async open(mnemonic: string, privatekey: string, id: string): Promise<KeyCreateResult | undefined> {
 
-    const result: boolean = await this.dialog
+    const result: KeyCreateResult = await this.dialog
       .open(KeyBackupDialogComponent, {
-        data: { mnemonic: mnemonic, privatekey: privatekey },
+        data: { mnemonic: mnemonic, privatekey: privatekey, id: id },
       })
       .afterClosed()
       .toPromise();

--- a/projects/main/src/app/models/keys/key-backup-dialog.service.ts
+++ b/projects/main/src/app/models/keys/key-backup-dialog.service.ts
@@ -1,20 +1,19 @@
-import { Injectable } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
 import { KeyBackupDialogComponent } from '../../views/keys/key-backup-dialog/key-backup-dialog.component';
 import { KeyCreateResult } from './key.model';
+import { Injectable } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class KeyBackupDialogService {
+  constructor(public matDialog: MatDialog, private readonly dialog: MatDialog) {}
 
-  constructor(
-    public matDialog: MatDialog,
-    private readonly dialog: MatDialog,
-  ) { }
-
-  async open(mnemonic: string, privatekey: string, id: string): Promise<KeyCreateResult | undefined> {
-
+  async open(
+    mnemonic: string,
+    privatekey: string,
+    id: string,
+  ): Promise<KeyCreateResult | undefined> {
     const result: KeyCreateResult = await this.dialog
       .open(KeyBackupDialogComponent, {
         data: { mnemonic: mnemonic, privatekey: privatekey, id: id },
@@ -24,5 +23,4 @@ export class KeyBackupDialogService {
 
     return result;
   }
-
 }

--- a/projects/main/src/app/models/keys/key-backup-dialog.service.ts
+++ b/projects/main/src/app/models/keys/key-backup-dialog.service.ts
@@ -1,5 +1,5 @@
 import { KeyBackupDialogComponent } from '../../views/keys/key-backup-dialog/key-backup-dialog.component';
-import { KeyCreateResult } from './key.model';
+import { KeyBackupResult } from './key.model';
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -13,14 +13,14 @@ export class KeyBackupDialogService {
     mnemonic: string,
     privatekey: string,
     id: string,
-  ): Promise<KeyCreateResult | undefined> {
-    const result: KeyCreateResult = await this.dialog
+  ): Promise<KeyBackupResult | undefined> {
+    const keyBackupResult: KeyBackupResult = await this.dialog
       .open(KeyBackupDialogComponent, {
         data: { mnemonic: mnemonic, privatekey: privatekey, id: id },
       })
       .afterClosed()
       .toPromise();
 
-    return result;
+    return keyBackupResult;
   }
 }

--- a/projects/main/src/app/models/keys/key-backup-dialog.service.ts
+++ b/projects/main/src/app/models/keys/key-backup-dialog.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { KeyBackupDialogComponent } from '../../views/keys/key-backup-dialog/key-backup-dialog.component';
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class KeyBackupDialogService {
+
+  constructor(
+    public matDialog: MatDialog,
+    private readonly dialog: MatDialog,
+  ) { }
+
+  async open(): Promise<boolean | undefined> {
+
+    const result: boolean | undefined = await this.dialog
+      .open(KeyBackupDialogComponent, {
+        //Todo：ダイアログに何か渡す必要があるか検討。
+        //data: { keys, currentKeyID: currentKey?.id },
+      })
+      .afterClosed()
+      .toPromise();
+
+    //Todo:現在は閉じたら、0を返す。
+    //     返ってくる「checked」を判断に使用する。
+    return result;
+  }
+
+}

--- a/projects/main/src/app/models/keys/key-backup-dialog.service.ts
+++ b/projects/main/src/app/models/keys/key-backup-dialog.service.ts
@@ -13,12 +13,12 @@ export class KeyBackupDialogService {
     private readonly dialog: MatDialog,
   ) { }
 
-  async open(): Promise<boolean | undefined> {
+  async open(mnemonic: string, privatekey: string): Promise<boolean> {
 
-    const result: boolean | undefined = await this.dialog
+    const result: boolean = await this.dialog
       .open(KeyBackupDialogComponent, {
-        //Todo：ダイアログに何か渡す必要があるか検討。
-        //data: { keys, currentKeyID: currentKey?.id },
+        //Todo：ダイアログに何か渡す必要があるか検討。→pubkeyとニーモニック
+        data: { mnemonic: mnemonic, privatekey: privatekey },
       })
       .afterClosed()
       .toPromise();

--- a/projects/main/src/app/models/keys/key-backup-dialog.service.ts
+++ b/projects/main/src/app/models/keys/key-backup-dialog.service.ts
@@ -13,18 +13,15 @@ export class KeyBackupDialogService {
     private readonly dialog: MatDialog,
   ) { }
 
-  async open(mnemonic: string, privatekey: string): Promise<boolean> {
+  async open(mnemonic: string, privatekey: string): Promise<boolean | undefined> {
 
     const result: boolean = await this.dialog
       .open(KeyBackupDialogComponent, {
-        //Todo：ダイアログに何か渡す必要があるか検討。→pubkeyとニーモニック
         data: { mnemonic: mnemonic, privatekey: privatekey },
       })
       .afterClosed()
       .toPromise();
 
-    //Todo:現在は閉じたら、0を返す。
-    //     返ってくる「checked」を判断に使用する。
     return result;
   }
 

--- a/projects/main/src/app/models/keys/key.model.ts
+++ b/projects/main/src/app/models/keys/key.model.ts
@@ -10,7 +10,7 @@ export type Key = {
   public_key: string;
 };
 
-export type KeyCreateResult = {
+export type KeyBackupResult = {
   saved: Boolean;
   checked: Boolean;
 };

--- a/projects/main/src/app/models/keys/key.model.ts
+++ b/projects/main/src/app/models/keys/key.model.ts
@@ -9,3 +9,8 @@ export type Key = {
   type: KeyType;
   public_key: string;
 };
+
+export type KeyCreateResult = {
+  saved: Boolean;
+  checked: Boolean;
+};

--- a/projects/main/src/app/pages/keys/create/create.component.ts
+++ b/projects/main/src/app/pages/keys/create/create.component.ts
@@ -1,11 +1,11 @@
+import { KeyBackupDialogService } from '../../../models/keys/key-backup-dialog.service';
+import { KeyCreateResult } from '../../../models/keys/key.model';
 import { KeyService } from '../../../models/keys/key.service';
 import { CreateOnSubmitEvent } from '../../../views/keys/create/create.component';
 import { Component, OnInit } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import * as bip39 from 'bip39';
 import { KeyApplicationService } from 'projects/main/src/app/models/keys/key.application.service';
-import { KeyBackupDialogService } from '../../../models/keys/key-backup-dialog.service';
-import { KeyCreateResult } from '../../../models/keys/key.model';
-import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-create',
@@ -15,7 +15,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 export class CreateComponent implements OnInit {
   mnemonic: string;
   privateKey: string;
-  createResult: KeyCreateResult | undefined
+  createResult: KeyCreateResult | undefined;
 
   constructor(
     private readonly keyApplication: KeyApplicationService,
@@ -27,7 +27,7 @@ export class CreateComponent implements OnInit {
     this.privateKey = '';
   }
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 
   onClickCreateMnemonic() {
     this.mnemonic = bip39.generateMnemonic();
@@ -42,8 +42,11 @@ export class CreateComponent implements OnInit {
   }
 
   async onSubmit($event: CreateOnSubmitEvent) {
-
-    this.createResult = await this.keyBackupDialog.open(this.mnemonic, $event.privateKey, $event.id);
+    this.createResult = await this.keyBackupDialog.open(
+      this.mnemonic,
+      $event.privateKey,
+      $event.id,
+    );
     //const createResult: KeyCreateResult | undefined = await this.keyBackupDialog.open(this.mnemonic, $event.privateKey, $event.id);
 
     if (this.createResult?.checked === true) {

--- a/projects/main/src/app/pages/keys/create/create.component.ts
+++ b/projects/main/src/app/pages/keys/create/create.component.ts
@@ -13,7 +13,6 @@ import { KeyBackupDialogService } from '../../../models/keys/key-backup-dialog.s
 export class CreateComponent implements OnInit {
   mnemonic: string;
   privateKey: string;
-  saved: boolean = false;
 
   constructor(
     private readonly keyApplication: KeyApplicationService,
@@ -39,12 +38,8 @@ export class CreateComponent implements OnInit {
   }
 
   async onSubmit($event: CreateOnSubmitEvent) {
-
-    this.saved = await this.keyBackupDialog.open(this.mnemonic, $event.privateKey);
-
-    //todo:ダイアログ閉じたら0、ダイアログ外でundefined→保存の有無で制御
-    console.log("checked", typeof (this.saved), this.saved)
-    if (this.saved === true) {
+    const saved: boolean | undefined = await this.keyBackupDialog.open(this.mnemonic, $event.privateKey);
+    if (saved === true) {
       await this.keyApplication.create($event.id, $event.type, $event.privateKey);
     }
   }

--- a/projects/main/src/app/pages/keys/create/create.component.ts
+++ b/projects/main/src/app/pages/keys/create/create.component.ts
@@ -3,6 +3,7 @@ import { CreateOnSubmitEvent } from '../../../views/keys/create/create.component
 import { Component, OnInit } from '@angular/core';
 import * as bip39 from 'bip39';
 import { KeyApplicationService } from 'projects/main/src/app/models/keys/key.application.service';
+import { KeyBackupDialogService } from '../../../models/keys/key-backup-dialog.service';
 
 @Component({
   selector: 'app-create',
@@ -16,12 +17,13 @@ export class CreateComponent implements OnInit {
   constructor(
     private readonly keyApplication: KeyApplicationService,
     private readonly key: KeyService,
+    private readonly keyBackupDialog: KeyBackupDialogService,
   ) {
     this.mnemonic = '';
     this.privateKey = '';
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void { }
 
   onClickCreateMnemonic() {
     this.mnemonic = bip39.generateMnemonic();
@@ -36,6 +38,13 @@ export class CreateComponent implements OnInit {
   }
 
   async onSubmit($event: CreateOnSubmitEvent) {
-    await this.keyApplication.create($event.id, $event.type, $event.privateKey);
+
+    let checked: boolean | undefined = await this.keyBackupDialog.open();
+
+    //todo:ダイアログ閉じたら0、ダイアログ外でundefined→保存の有無で制御
+    console.log("checked", typeof (checked), checked)
+    if (!checked === true) {
+      await this.keyApplication.create($event.id, $event.type, $event.privateKey);
+    }
   }
 }

--- a/projects/main/src/app/pages/keys/create/create.component.ts
+++ b/projects/main/src/app/pages/keys/create/create.component.ts
@@ -1,5 +1,5 @@
 import { KeyBackupDialogService } from '../../../models/keys/key-backup-dialog.service';
-import { KeyCreateResult } from '../../../models/keys/key.model';
+import { KeyBackupResult } from '../../../models/keys/key.model';
 import { KeyService } from '../../../models/keys/key.service';
 import { CreateOnSubmitEvent } from '../../../views/keys/create/create.component';
 import { Component, OnInit } from '@angular/core';
@@ -15,7 +15,7 @@ import { KeyApplicationService } from 'projects/main/src/app/models/keys/key.app
 export class CreateComponent implements OnInit {
   mnemonic: string;
   privateKey: string;
-  createResult: KeyCreateResult | undefined;
+  keyBackupResult: KeyBackupResult | undefined;
 
   constructor(
     private readonly keyApplication: KeyApplicationService,
@@ -42,14 +42,14 @@ export class CreateComponent implements OnInit {
   }
 
   async onSubmit($event: CreateOnSubmitEvent) {
-    this.createResult = await this.keyBackupDialog.open(
+    this.keyBackupResult = await this.keyBackupDialog.open(
       this.mnemonic,
       $event.privateKey,
       $event.id,
     );
     //const createResult: KeyCreateResult | undefined = await this.keyBackupDialog.open(this.mnemonic, $event.privateKey, $event.id);
 
-    if (this.createResult?.checked === true) {
+    if (this.keyBackupResult?.checked === true) {
       await this.keyApplication.create($event.id, $event.type, $event.privateKey);
     } else {
       this.snackBar.open('create failed', undefined, {

--- a/projects/main/src/app/pages/keys/create/create.component.ts
+++ b/projects/main/src/app/pages/keys/create/create.component.ts
@@ -4,6 +4,8 @@ import { Component, OnInit } from '@angular/core';
 import * as bip39 from 'bip39';
 import { KeyApplicationService } from 'projects/main/src/app/models/keys/key.application.service';
 import { KeyBackupDialogService } from '../../../models/keys/key-backup-dialog.service';
+import { KeyCreateResult } from '../../../models/keys/key.model';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-create',
@@ -13,11 +15,13 @@ import { KeyBackupDialogService } from '../../../models/keys/key-backup-dialog.s
 export class CreateComponent implements OnInit {
   mnemonic: string;
   privateKey: string;
+  createResult: KeyCreateResult | undefined
 
   constructor(
     private readonly keyApplication: KeyApplicationService,
     private readonly key: KeyService,
     private readonly keyBackupDialog: KeyBackupDialogService,
+    private readonly snackBar: MatSnackBar,
   ) {
     this.mnemonic = '';
     this.privateKey = '';
@@ -38,9 +42,16 @@ export class CreateComponent implements OnInit {
   }
 
   async onSubmit($event: CreateOnSubmitEvent) {
-    const saved: boolean | undefined = await this.keyBackupDialog.open(this.mnemonic, $event.privateKey);
-    if (saved === true) {
+
+    this.createResult = await this.keyBackupDialog.open(this.mnemonic, $event.privateKey, $event.id);
+    //const createResult: KeyCreateResult | undefined = await this.keyBackupDialog.open(this.mnemonic, $event.privateKey, $event.id);
+
+    if (this.createResult?.checked === true) {
       await this.keyApplication.create($event.id, $event.type, $event.privateKey);
+    } else {
+      this.snackBar.open('create failed', undefined, {
+        duration: 3000,
+      });
     }
   }
 }

--- a/projects/main/src/app/pages/keys/create/create.component.ts
+++ b/projects/main/src/app/pages/keys/create/create.component.ts
@@ -13,6 +13,7 @@ import { KeyBackupDialogService } from '../../../models/keys/key-backup-dialog.s
 export class CreateComponent implements OnInit {
   mnemonic: string;
   privateKey: string;
+  saved: boolean = false;
 
   constructor(
     private readonly keyApplication: KeyApplicationService,
@@ -39,11 +40,11 @@ export class CreateComponent implements OnInit {
 
   async onSubmit($event: CreateOnSubmitEvent) {
 
-    let checked: boolean | undefined = await this.keyBackupDialog.open();
+    this.saved = await this.keyBackupDialog.open(this.mnemonic, $event.privateKey);
 
     //todo:ダイアログ閉じたら0、ダイアログ外でundefined→保存の有無で制御
-    console.log("checked", typeof (checked), checked)
-    if (!checked === true) {
+    console.log("checked", typeof (this.saved), this.saved)
+    if (this.saved === true) {
       await this.keyApplication.create($event.id, $event.type, $event.privateKey);
     }
   }

--- a/projects/main/src/app/pages/keys/create/create.component.ts
+++ b/projects/main/src/app/pages/keys/create/create.component.ts
@@ -15,7 +15,7 @@ import { KeyApplicationService } from 'projects/main/src/app/models/keys/key.app
 export class CreateComponent implements OnInit {
   mnemonic: string;
   privateKey: string;
-  keyBackupResult: KeyBackupResult | undefined;
+  keyBackupResult?: KeyBackupResult;
 
   constructor(
     private readonly keyApplication: KeyApplicationService,
@@ -31,7 +31,17 @@ export class CreateComponent implements OnInit {
 
   onClickCreateMnemonic() {
     this.mnemonic = bip39.generateMnemonic();
-    window.alert('You must memory this mnemonic.');
+    window.alert(
+      '\
+You must memory this mnemonic and private key.\n\
+If you lose both your mnemonic and private key,\n\
+you will never be able to restore your account.\n\
+In the dialog box that appears after you click the submit button,\n\
+make sure to download the backup files of mnemonic and private key,\n\
+and store them safely and confidentially without disclosing them to others.\
+    ',
+    );
+    this.keyBackupResult = undefined;
   }
 
   async onBlurMnemonic(mnemonic: string) {
@@ -39,6 +49,7 @@ export class CreateComponent implements OnInit {
       return;
     }
     this.privateKey = await this.key.getPrivateKeyFromMnemonic(mnemonic);
+    this.keyBackupResult = undefined;
   }
 
   async onSubmit($event: CreateOnSubmitEvent) {
@@ -47,9 +58,8 @@ export class CreateComponent implements OnInit {
       $event.privateKey,
       $event.id,
     );
-    //const createResult: KeyCreateResult | undefined = await this.keyBackupDialog.open(this.mnemonic, $event.privateKey, $event.id);
 
-    if (this.keyBackupResult?.checked === true) {
+    if (this.keyBackupResult?.saved === true && this.keyBackupResult?.checked === true) {
       await this.keyApplication.create($event.id, $event.type, $event.privateKey);
     } else {
       this.snackBar.open('create failed', undefined, {

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.html
@@ -1,9 +1,66 @@
-<form #formRef="ngForm" (submit)="onClickOkButton()">
+<mat-stepper orientation="vertical" linear #stepper>
+  <!--
+  <mat-step [stepControl]="firstFormGroup" errorMessage="Name is required.">
 
-  <mat-checkbox>Click to Check me!</mat-checkbox>
+    <form [formGroup]="firstFormGroup">
+    </form>
+  -->
+  <mat-step>
+    <ng-template matStepLabel>Save your Mnemonic</ng-template>
+    <!--
+      <mat-form-field appearance="fill">
+        <mat-label>Name</mat-label>
+        <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
+      </mat-form-field>
+      -->
+    <button mat-flat-button class="w-full" color="accent" (click)="saveMnemonic()">
+      Save Mnemonic
+    </button>
+    <mat-checkbox>I saved my Mnemonic</mat-checkbox>
+    <div>
+      <button mat-flat-button class="w-1/2" color="accent" matStepperNext>Next</button>
+    </div>
+  </mat-step>
+  <!--
+  <mat-step [stepControl]="secondFormGroup" errorMessage="Address is required.">
+    <form [formGroup]="secondFormGroup">
+      <ng-template matStepLabel>Fill out your address</ng-template>
+      <mat-form-field appearance="fill">
+        <mat-label>Address</mat-label>
+        <input matInput placeholder="Ex. 1 Main St, New York, NY" formControlName="secondCtrl" required>
+      </mat-form-field>
+      <div>
+        <p>Go to a different step to see the error state</p>
+        <button mat-button matStepperPrevious>Back</button>
+        <button mat-button matStepperNext>Next</button>
+      </div>
+    </form>
+  </mat-step>
+  -->
+  <mat-step>
+    <ng-template matStepLabel>third</ng-template>
+    <div>
+      <p>Go to nest</p>
+      <button mat-flat-button class="w-1/2" color="accent" matStepperPrevious>Back</button>
+      <button mat-button matStepperNext>Next</button>
+    </div>
+  </mat-step>
 
-  <button mat-flat-button class="w-full" color="accent">
-    Submit
-  </button>
+  <mat-step>
+    <ng-template matStepLabel>submit</ng-template>
+    <button mat-flat-button class="w-1/2" color="accent" matStepperPrevious>Back</button>
+    <button mat-flat-button class="w-1/2" color="accent" (click)="onClickOkButton(this.saved)">
+      Submit
+    </button>
+  </mat-step>
 
-</form>
+  <!--
+  <mat-step>
+    <ng-template matStepLabel>Done</ng-template>
+    <p>You are now done.</p>
+    <div>
+      <button mat-button (click)="stepper.reset()">Reset</button>
+    </div>
+  </mat-step>
+  -->
+</mat-stepper>

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.html
@@ -1,12 +1,14 @@
 <mat-stepper orientation="vertical" linear #stepper>
   <mat-step [completed]="saved">
     <ng-template matStepLabel>Save your Mnemonic</ng-template>
-    <div>
+    <div class="mb-2">
       <button mat-flat-button class="w-full" color="accent" (click)="saveMnemonic()">
         Download
       </button>
     </div>
-    <button mat-button [disabled]="!saved" matStepperNext>Next</button>
+    <div class="flex justify-end">
+      <button mat-flat-button color="primary" [disabled]="!saved" matStepperNext>Next</button>
+    </div>
   </mat-step>
   <mat-step [completed]="checked">
     <form #formRef="ngForm" (submit)="checkSaveMnemonic(inputMnemonic)">
@@ -16,19 +18,21 @@
         <mat-label>mnemonic</mat-label>
         <input matInput required name="mnemonic" [(ngModel)]="inputMnemonic">
       </mat-form-field>
-      <div>
-        <button mat-flat-button class="w-1/4" color="accent">Check</button>
+      <div class="mb-2">
+        <button mat-flat-button class="w-full" color="accent">Check</button>
       </div>
     </form>
-    <div>
-      <button mat-button matStepperPrevious>Back</button>
-      <button mat-button [disabled]="!checked" matStepperNext>Next</button>
+    <div class="flex justify-between">
+      <button mat-flat-button matStepperPrevious>Back</button>
+      <button mat-flat-button color="primary" [disabled]="!checked" matStepperNext>Next</button>
     </div>
   </mat-step>
   <mat-step>
     <ng-template matStepLabel>Submit</ng-template>
-    <button mat-button matStepperPrevious>Back</button>
-    <button mat-flat-button class="w-1/2" color="accent" (click)="onClickSubmit(this.saved)">
+    <div class="mb-2 flex justify-start">
+      <button mat-flat-button matStepperPrevious>Back</button>
+    </div>
+    <button mat-flat-button class="w-full" color="accent" [disabled]="!checked || !saved" (click)="onClickSubmit(this.saved)">
       Submit
     </button>
   </mat-step>

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.html
@@ -1,0 +1,9 @@
+<form #formRef="ngForm" (submit)="onClickOkButton()">
+
+  <mat-checkbox>Click to Check me!</mat-checkbox>
+
+  <button mat-flat-button class="w-full" color="accent">
+    Submit
+  </button>
+
+</form>

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.html
@@ -32,7 +32,7 @@
     <div class="mb-2 flex justify-start">
       <button mat-flat-button matStepperPrevious>Back</button>
     </div>
-    <button mat-flat-button class="w-full" color="accent" [disabled]="!checked || !saved" (click)="onClickSubmit(this.saved)">
+    <button mat-flat-button class="w-full" color="accent" [disabled]="!checked || !saved" (click)="onClickSubmit()">
       Submit
     </button>
   </mat-step>

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.html
@@ -6,26 +6,29 @@
         Download
       </button>
     </div>
-    <button mat-button matStepperNext>Next</button>
+    <button mat-button [disabled]="!saved" matStepperNext>Next</button>
   </mat-step>
-  <mat-step>
+  <mat-step [completed]="checked">
     <form #formRef="ngForm" (submit)="checkSaveMnemonic(inputMnemonic)">
-      <ng-template matStepLabel>check</ng-template>
+      <ng-template matStepLabel>Check</ng-template>
       <p>Input {{ordinal(requiredMnemonicNumber)}} mnemonic</p>
       <mat-form-field appearance="fill">
         <mat-label>mnemonic</mat-label>
         <input matInput required name="mnemonic" [(ngModel)]="inputMnemonic">
       </mat-form-field>
       <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext>Next</button>
+        <button mat-flat-button class="w-1/4" color="accent">Check</button>
       </div>
     </form>
+    <div>
+      <button mat-button matStepperPrevious>Back</button>
+      <button mat-button [disabled]="!checked" matStepperNext>Next</button>
+    </div>
   </mat-step>
   <mat-step>
-    <ng-template matStepLabel>submit</ng-template>
+    <ng-template matStepLabel>Submit</ng-template>
     <button mat-button matStepperPrevious>Back</button>
-    <button mat-flat-button class="w-1/2" color="accent" (click)="onClickOkButton(this.saved)">
+    <button mat-flat-button class="w-1/2" color="accent" (click)="onClickSubmit(this.saved)">
       Submit
     </button>
   </mat-step>

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.html
@@ -1,66 +1,32 @@
 <mat-stepper orientation="vertical" linear #stepper>
-  <!--
-  <mat-step [stepControl]="firstFormGroup" errorMessage="Name is required.">
-
-    <form [formGroup]="firstFormGroup">
-    </form>
-  -->
-  <mat-step>
+  <mat-step [completed]="saved">
     <ng-template matStepLabel>Save your Mnemonic</ng-template>
-    <!--
-      <mat-form-field appearance="fill">
-        <mat-label>Name</mat-label>
-        <input matInput placeholder="Last name, First name" formControlName="firstCtrl" required>
-      </mat-form-field>
-      -->
-    <button mat-flat-button class="w-full" color="accent" (click)="saveMnemonic()">
-      Save Mnemonic
-    </button>
-    <mat-checkbox>I saved my Mnemonic</mat-checkbox>
     <div>
-      <button mat-flat-button class="w-1/2" color="accent" matStepperNext>Next</button>
+      <button mat-flat-button class="w-full" color="accent" (click)="saveMnemonic()">
+        Download
+      </button>
     </div>
+    <button mat-button matStepperNext>Next</button>
   </mat-step>
-  <!--
-  <mat-step [stepControl]="secondFormGroup" errorMessage="Address is required.">
-    <form [formGroup]="secondFormGroup">
-      <ng-template matStepLabel>Fill out your address</ng-template>
+  <mat-step>
+    <form #formRef="ngForm" (submit)="checkSaveMnemonic(inputMnemonic)">
+      <ng-template matStepLabel>check</ng-template>
+      <p>Input {{ordinal(requiredMnemonicNumber)}} mnemonic</p>
       <mat-form-field appearance="fill">
-        <mat-label>Address</mat-label>
-        <input matInput placeholder="Ex. 1 Main St, New York, NY" formControlName="secondCtrl" required>
+        <mat-label>mnemonic</mat-label>
+        <input matInput required name="mnemonic" [(ngModel)]="inputMnemonic">
       </mat-form-field>
       <div>
-        <p>Go to a different step to see the error state</p>
         <button mat-button matStepperPrevious>Back</button>
         <button mat-button matStepperNext>Next</button>
       </div>
     </form>
   </mat-step>
-  -->
-  <mat-step>
-    <ng-template matStepLabel>third</ng-template>
-    <div>
-      <p>Go to nest</p>
-      <button mat-flat-button class="w-1/2" color="accent" matStepperPrevious>Back</button>
-      <button mat-button matStepperNext>Next</button>
-    </div>
-  </mat-step>
-
   <mat-step>
     <ng-template matStepLabel>submit</ng-template>
-    <button mat-flat-button class="w-1/2" color="accent" matStepperPrevious>Back</button>
+    <button mat-button matStepperPrevious>Back</button>
     <button mat-flat-button class="w-1/2" color="accent" (click)="onClickOkButton(this.saved)">
       Submit
     </button>
   </mat-step>
-
-  <!--
-  <mat-step>
-    <ng-template matStepLabel>Done</ng-template>
-    <p>You are now done.</p>
-    <div>
-      <button mat-button (click)="stepper.reset()">Reset</button>
-    </div>
-  </mat-step>
-  -->
 </mat-stepper>

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
@@ -12,8 +12,13 @@ import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
 })
 export class KeyBackupDialogComponent implements OnInit {
 
-  checked: boolean = false;
   saved: boolean = false;
+  checked: boolean = false;
+  inputMnemonic: string = "";
+
+  now = new Date();
+  sec = this.now.getSeconds();
+  requiredMnemonicNumber = this.sec % 12
 
   constructor(
     @Inject(MAT_DIALOG_DATA)
@@ -27,21 +32,24 @@ export class KeyBackupDialogComponent implements OnInit {
   onClickOkButton(input: boolean): void {
     // ボタンが押されたときは「checked」を呼び出し元に渡す。
     //Todo:渡した「checked」を判断に使用する。
-    console.log("create-dialog,saved", input)
     this.matDialogRef.close(this.checked);
   }
 
-  saveMnemonic(): void {
+  ordinal(n: number): string {
+    if (n == 0) return "1st"
+    if (n == 1) return "2nd"
+    if (n == 2) return "3rd"
+    return String(n + 1) + "th"
+  }
 
+  saveMnemonic(): void {
     //prefix
-    const now = new Date();
-    const year = String(now.getFullYear());
-    const month = String(now.getMonth() + 1);
-    const date = String(now.getDate());
-    const hour = String(now.getHours());
-    const min = String(now.getMinutes());
-    const sec = String(now.getSeconds());
-    const time = year + month + date + hour + min + sec;
+    const year = String(this.now.getFullYear());
+    const month = String(this.now.getMonth() + 1);
+    const date = String(this.now.getDate());
+    const hour = String(this.now.getHours());
+    const min = String(this.now.getMinutes());
+    const time = year + month + date + hour + min + String(this.sec);
 
     //filename
     const filetype = '.txt';
@@ -56,6 +64,17 @@ export class KeyBackupDialogComponent implements OnInit {
     link.href = 'data:text/plain,' + encodeURIComponent(data);
     link.download = fileName;
     link.click();
+
+    //status
+    this.saved = true;
+  }
+
+  private mnemonicArray = this.data.mnemonic.split(/\s/)
+
+  checkSaveMnemonic(str: string): void {
+    if (this.mnemonicArray[this.requiredMnemonicNumber] === str) {
+      this.checked = true;
+    }
   }
 
   ngOnInit(): void {

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
@@ -1,3 +1,4 @@
+import { KeyBackupResult } from '../../../models/keys/key.model';
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
 import { Component, OnInit, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
@@ -36,7 +37,8 @@ export class KeyBackupDialogComponent implements OnInit {
   ) {}
 
   onClickSubmit(input: boolean): void {
-    this.matDialogRef.close({ saved: this.saved, checked: this.checked });
+    const keyBackupResult: KeyBackupResult = { saved: this.saved, checked: this.checked };
+    this.matDialogRef.close(keyBackupResult);
   }
 
   ordinal(n: number): string {
@@ -47,7 +49,7 @@ export class KeyBackupDialogComponent implements OnInit {
   }
 
   saveMnemonic(): void {
-    //prefix
+    //postfix
     const year = String(this.now.getFullYear());
     const month = String(this.now.getMonth() + 1);
     const date = String(this.now.getDate());

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
@@ -1,0 +1,35 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-key-backup-dialog',
+  templateUrl: './key-backup-dialog.component.html',
+  styleUrls: ['./key-backup-dialog.component.css']
+})
+export class KeyBackupDialogComponent implements OnInit {
+
+  checked: boolean = false
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA)
+    public data: any,
+    /*Todo：何か受け取る必要があるか検討。
+    public readonly data: {
+      keys: Key[];
+      currentKeyID: string | undefined;
+    },
+    */
+    public matDialogRef: MatDialogRef<KeyBackupDialogComponent>
+  ) { }
+
+  onClickOkButton(): void {
+    // ボタンが押されたときは「checked」を呼び出し元に渡す。
+    //Todo:渡した「checked」を判断に使用する。
+    this.matDialogRef.close(this.checked);
+  }
+
+  ngOnInit(): void {
+  }
+
+}
+

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
@@ -59,7 +59,7 @@ export class KeyBackupDialogComponent implements OnInit {
 
     //filename
     const filetype = '.txt';
-    const fileName = this.data.id + time + filetype;
+    const fileName = 'key-' + this.data.id + '-' + time + filetype;
 
     //data
     const data =
@@ -89,6 +89,7 @@ export class KeyBackupDialogComponent implements OnInit {
         duration: 2000,
       });
     } else {
+      this.checked = false;
       this.snackBar.open('wrong mnemonic', undefined, {
         duration: 300,
       });

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-key-backup-dialog',
@@ -19,20 +20,21 @@ export class KeyBackupDialogComponent implements OnInit {
   now = new Date();
   sec = this.now.getSeconds();
   requiredMnemonicNumber = this.sec % 12
+  private mnemonicArray = this.data.mnemonic.split(/\s/)
 
   constructor(
     @Inject(MAT_DIALOG_DATA)
     public readonly data: {
       mnemonic: string,
-      privatekey: string
+      privatekey: string,
+      id: string
     },
     public matDialogRef: MatDialogRef<KeyBackupDialogComponent>,
+    private readonly snackBar: MatSnackBar,
   ) { }
 
-  onClickOkButton(input: boolean): void {
-    // ボタンが押されたときは「checked」を呼び出し元に渡す。
-    //Todo:渡した「checked」を判断に使用する。
-    this.matDialogRef.close(this.checked);
+  onClickSubmit(input: boolean): void {
+    this.matDialogRef.close({ saved: this.saved, checked: this.checked });
   }
 
   ordinal(n: number): string {
@@ -53,10 +55,11 @@ export class KeyBackupDialogComponent implements OnInit {
 
     //filename
     const filetype = '.txt';
-    const fileName = "key" + time + filetype;
+    const fileName = this.data.id + time + filetype;
 
     //data
-    const data = "private key : " + this.data.privatekey + "\n"
+    const data = "key ID : " + this.data.id + "\n"
+      + "private key : " + this.data.privatekey + "\n"
       + "mnemonic : " + this.data.mnemonic;
 
     //HTML link
@@ -69,11 +72,16 @@ export class KeyBackupDialogComponent implements OnInit {
     this.saved = true;
   }
 
-  private mnemonicArray = this.data.mnemonic.split(/\s/)
-
   checkSaveMnemonic(str: string): void {
     if (this.mnemonicArray[this.requiredMnemonicNumber] === str) {
       this.checked = true;
+      this.snackBar.open('collect', undefined, {
+        duration: 2000,
+      });
+    } else {
+      this.snackBar.open('wrong mnemonic', undefined, {
+        duration: 300,
+      });
     }
   }
 

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
@@ -1,31 +1,61 @@
 import { Component, OnInit, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
 
 @Component({
   selector: 'app-key-backup-dialog',
   templateUrl: './key-backup-dialog.component.html',
-  styleUrls: ['./key-backup-dialog.component.css']
+  styleUrls: ['./key-backup-dialog.component.css'],
+  providers: [{
+    provide: STEPPER_GLOBAL_OPTIONS, useValue: { showError: true }
+  }]
 })
 export class KeyBackupDialogComponent implements OnInit {
 
-  checked: boolean = false
+  checked: boolean = false;
+  saved: boolean = false;
 
   constructor(
     @Inject(MAT_DIALOG_DATA)
-    public data: any,
-    /*Todo：何か受け取る必要があるか検討。
     public readonly data: {
-      keys: Key[];
-      currentKeyID: string | undefined;
+      mnemonic: string,
+      privatekey: string
     },
-    */
-    public matDialogRef: MatDialogRef<KeyBackupDialogComponent>
+    public matDialogRef: MatDialogRef<KeyBackupDialogComponent>,
   ) { }
 
-  onClickOkButton(): void {
+  onClickOkButton(input: boolean): void {
     // ボタンが押されたときは「checked」を呼び出し元に渡す。
     //Todo:渡した「checked」を判断に使用する。
+    console.log("create-dialog,saved", input)
     this.matDialogRef.close(this.checked);
+  }
+
+  saveMnemonic(): void {
+
+    //prefix
+    const now = new Date();
+    const year = String(now.getFullYear());
+    const month = String(now.getMonth() + 1);
+    const date = String(now.getDate());
+    const hour = String(now.getHours());
+    const min = String(now.getMinutes());
+    const sec = String(now.getSeconds());
+    const time = year + month + date + hour + min + sec;
+
+    //filename
+    const filetype = '.txt';
+    const fileName = "key" + time + filetype;
+
+    //data
+    const data = "private key : " + this.data.privatekey + "\n"
+      + "mnemonic : " + this.data.mnemonic;
+
+    //HTML link
+    const link = document.createElement('a');
+    link.href = 'data:text/plain,' + encodeURIComponent(data);
+    link.download = fileName;
+    link.click();
   }
 
   ngOnInit(): void {

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
@@ -36,7 +36,7 @@ export class KeyBackupDialogComponent implements OnInit {
     private readonly snackBar: MatSnackBar,
   ) {}
 
-  onClickSubmit(input: boolean): void {
+  onClickSubmit(): void {
     const keyBackupResult: KeyBackupResult = { saved: this.saved, checked: this.checked };
     this.matDialogRef.close(keyBackupResult);
   }

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
@@ -1,47 +1,49 @@
+import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
 import { Component, OnInit, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-key-backup-dialog',
   templateUrl: './key-backup-dialog.component.html',
   styleUrls: ['./key-backup-dialog.component.css'],
-  providers: [{
-    provide: STEPPER_GLOBAL_OPTIONS, useValue: { showError: true }
-  }]
+  providers: [
+    {
+      provide: STEPPER_GLOBAL_OPTIONS,
+      useValue: { showError: true },
+    },
+  ],
 })
 export class KeyBackupDialogComponent implements OnInit {
-
   saved: boolean = false;
   checked: boolean = false;
-  inputMnemonic: string = "";
+  inputMnemonic: string = '';
 
   now = new Date();
   sec = this.now.getSeconds();
-  requiredMnemonicNumber = this.sec % 12
-  private mnemonicArray = this.data.mnemonic.split(/\s/)
+  requiredMnemonicNumber = this.sec % 12;
+  private mnemonicArray = this.data.mnemonic.split(/\s/);
 
   constructor(
     @Inject(MAT_DIALOG_DATA)
     public readonly data: {
-      mnemonic: string,
-      privatekey: string,
-      id: string
+      mnemonic: string;
+      privatekey: string;
+      id: string;
     },
     public matDialogRef: MatDialogRef<KeyBackupDialogComponent>,
     private readonly snackBar: MatSnackBar,
-  ) { }
+  ) {}
 
   onClickSubmit(input: boolean): void {
     this.matDialogRef.close({ saved: this.saved, checked: this.checked });
   }
 
   ordinal(n: number): string {
-    if (n == 0) return "1st"
-    if (n == 1) return "2nd"
-    if (n == 2) return "3rd"
-    return String(n + 1) + "th"
+    if (n == 0) return '1st';
+    if (n == 1) return '2nd';
+    if (n == 2) return '3rd';
+    return String(n + 1) + 'th';
   }
 
   saveMnemonic(): void {
@@ -58,9 +60,15 @@ export class KeyBackupDialogComponent implements OnInit {
     const fileName = this.data.id + time + filetype;
 
     //data
-    const data = "key ID : " + this.data.id + "\n"
-      + "private key : " + this.data.privatekey + "\n"
-      + "mnemonic : " + this.data.mnemonic;
+    const data =
+      'key ID : ' +
+      this.data.id +
+      '\n' +
+      'private key : ' +
+      this.data.privatekey +
+      '\n' +
+      'mnemonic : ' +
+      this.data.mnemonic;
 
     //HTML link
     const link = document.createElement('a');
@@ -85,8 +93,5 @@ export class KeyBackupDialogComponent implements OnInit {
     }
   }
 
-  ngOnInit(): void {
-  }
-
+  ngOnInit(): void {}
 }
-

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.module.ts
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { KeyBackupDialogComponent } from './key-backup-dialog.component';
+import { FormsModule } from '@angular/forms';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+
+@NgModule({
+  declarations: [KeyBackupDialogComponent],
+  imports: [
+    //Todo:必要なモジュールを絞る。
+    CommonModule, FormsModule, MatCheckboxModule
+  ],
+  exports: [KeyBackupDialogComponent],
+})
+export class KeyBackupDialogModule { }

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.module.ts
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.module.ts
@@ -2,11 +2,12 @@ import { MaterialModule } from '../../material.module';
 import { KeyBackupDialogComponent } from './key-backup-dialog.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { MatStepperModule } from '@angular/material/stepper';
 
 @NgModule({
   declarations: [KeyBackupDialogComponent],
-  imports: [CommonModule, MaterialModule, MatStepperModule],
+  imports: [CommonModule, MaterialModule, FormsModule, MatStepperModule],
   exports: [KeyBackupDialogComponent],
 })
 export class KeyBackupDialogModule { }

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.module.ts
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.module.ts
@@ -1,15 +1,12 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { MaterialModule } from '../../material.module';
 import { KeyBackupDialogComponent } from './key-backup-dialog.component';
-import { FormsModule } from '@angular/forms';
-import { MatCheckboxModule } from '@angular/material/checkbox';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { MatStepperModule } from '@angular/material/stepper';
 
 @NgModule({
   declarations: [KeyBackupDialogComponent],
-  imports: [
-    //Todo:必要なモジュールを絞る。
-    CommonModule, FormsModule, MatCheckboxModule
-  ],
+  imports: [CommonModule, MaterialModule, MatStepperModule],
   exports: [KeyBackupDialogComponent],
 })
 export class KeyBackupDialogModule { }


### PR DESCRIPTION
作成途中ですが、進捗報告のためPR作成します。
現在ダイアログcomponentとserviceを追加し、ダイアログ閉じるまでアカウント作成の処理を中断するところまで、作成しました。
引き続き、ニーモニックを保存する機能の追加と、保存したか確認するように実装を進めます。
![image](https://user-images.githubusercontent.com/75844498/138889733-a6b9072c-21d5-49b7-9947-1c149b995031.png)
