### PR TITLE
Icon height

### DIFF
--- a/projects/main/src/app/views/app.component.html
+++ b/projects/main/src/app/views/app.component.html
@@ -1,10 +1,6 @@
 <mat-drawer-container>
-  <mat-drawer
-    #drawer
-    class="mat-elevation-z16"
-    [mode]="(drawerMode$ | async) || 'over'"
-    [opened]="drawerOpened$ | async"
-  >
+  <mat-drawer #drawer class="mat-elevation-z16" [mode]="(drawerMode$ | async) || 'over'"
+    [opened]="drawerOpened$ | async">
     <mat-toolbar class="mat-elevation-z4 toolbar" color="primary">
       <button mat-icon-button routerLink="/">
         <img class="icon" src="/favicon.png" />
@@ -50,10 +46,7 @@
       <button mat-icon-button class="visible sm:invisible" (click)="drawer.toggle()">
         <mat-icon>menu</mat-icon>
       </button>
-      <view-toolbar
-        [searchValue]="searchValue"
-        (appSubmitSearchValue)="onSubmitSearchValue($event)"
-      ></view-toolbar>
+      <view-toolbar [searchValue]="searchValue" (appSubmitSearchValue)="onSubmitSearchValue($event)"></view-toolbar>
     </mat-toolbar>
     <div class="container">
       <ng-content></ng-content>

--- a/projects/main/src/app/views/app.component.html
+++ b/projects/main/src/app/views/app.component.html
@@ -2,10 +2,10 @@
   <mat-drawer #drawer class="mat-elevation-z16" [mode]="(drawerMode$ | async) || 'over'"
     [opened]="drawerOpened$ | async">
     <mat-toolbar class="mat-elevation-z4 toolbar" color="primary">
-      <button mat-icon-button routerLink="/">
-        <img class="p-2.5 w-10 h-10" src="/favicon.png" />
+      <button class="align-middle" mat-icon-button routerLink="/">
+        <img class="p-1 w-10 h-10" src="/favicon.png" />
       </button>
-      <h1>Telescope</h1>
+      <h1 class="align-middle">Telescope</h1>
     </mat-toolbar>
 
     <mat-nav-list>

--- a/projects/main/src/app/views/app.component.html
+++ b/projects/main/src/app/views/app.component.html
@@ -3,7 +3,7 @@
     [opened]="drawerOpened$ | async">
     <mat-toolbar class="mat-elevation-z4 toolbar" color="primary">
       <button mat-icon-button routerLink="/">
-        <img class="icon" src="/favicon.png" />
+        <img class="p-2.5 w-10 h-10" src="/favicon.png" />
       </button>
       <h1>Telescope</h1>
     </mat-toolbar>

--- a/projects/main/src/styles.css
+++ b/projects/main/src/styles.css
@@ -29,12 +29,4 @@ mat-progress-spinner {
   margin: 1em auto;
 }
 
-.icon {
-  padding: 4px;
-  min-width: 0;
-  width: 24px;
-  height: 24px;
-  flex-shrink: 0;
-  line-height: 40px;
-  border-radius: 50%;
-}
+


### PR DESCRIPTION
・サイドナビの40px枠に合うように、アイコンのサイズとpaddingを調整します。
（サイズ24pxを40pxに大きくします。アイコン自体の大きさを変えないよう、padding4pxを12pxに調整します。）
・上記変更をtailwindで実装するにあたって、不要と思われる以下のCSSを削除しました。
`.icon {
  padding: 4px;
  min-width: 0; //削除
  width: 24px;
  height: 24px;
  flex-shrink: 0; //削除
  line-height: 40px; //削除
  border-radius: 50%; //削除
}`
（単純置換tailwind→class="p-1 min-w-0 w-6 h-6 flex-shrink-0 leading-10 rounded-2xl"）
・アイコンが小さく見えたので、少し大きくしています。
（class="p-3 w-10 h-10”が見た目の大きさを変えない変換。）

![20211102_icon_tag2](https://user-images.githubusercontent.com/75844498/139855763-44335605-a51e-4388-b9ac-4a2b2c9f5909.png)
お手数ですが、ご確認お願い致します。