### PR TITLE
Fix create dialog

### DIFF
--- a/projects/main/src/app/pages/keys/create/create.component.ts
+++ b/projects/main/src/app/pages/keys/create/create.component.ts
@@ -27,7 +27,7 @@ export class CreateComponent implements OnInit {
     this.privateKey = '';
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void { }
 
   onClickCreateMnemonic() {
     this.mnemonic = bip39.generateMnemonic();
@@ -54,7 +54,7 @@ and store them safely and confidentially without disclosing them to others.\
 
   async onSubmit($event: CreateOnSubmitEvent) {
     this.keyBackupResult = await this.keyBackupDialog.open(
-      this.mnemonic,
+      $event.mnemonic,
       $event.privateKey,
       $event.id,
     );
@@ -62,7 +62,7 @@ and store them safely and confidentially without disclosing them to others.\
     if (this.keyBackupResult?.saved === true && this.keyBackupResult?.checked === true) {
       await this.keyApplication.create($event.id, $event.type, $event.privateKey);
     } else {
-      this.snackBar.open('create failed', undefined, {
+      this.snackBar.open('Create failed', undefined, {
         duration: 3000,
       });
     }

--- a/projects/main/src/app/views/blocks/blocks.component.html
+++ b/projects/main/src/app/views/blocks/blocks.component.html
@@ -1,4 +1,4 @@
-<h2>Latest Blocks</h2>
+<h2>Blocks</h2>
 <div>
   <mat-card>
     <mat-nav-list>

--- a/projects/main/src/app/views/keys/create/create.component.html
+++ b/projects/main/src/app/views/keys/create/create.component.html
@@ -1,4 +1,4 @@
-<form #formRef="ngForm" (submit)="onSubmit(idRef.value, typeRef.value, privateKeyRef.value)">
+<form #formRef="ngForm" (submit)="onSubmit(idRef.value, typeRef.value, privateKeyRef.value, mnemonicRef.value)">
   <mat-form-field class="w-full">
     <mat-label>ID</mat-label>
     <input #idRef ngModel name="id" matInput required pattern="^[a-z_][a-z_0-9]*$" autocomplete="username" />

--- a/projects/main/src/app/views/keys/create/create.component.ts
+++ b/projects/main/src/app/views/keys/create/create.component.ts
@@ -7,6 +7,7 @@ export type CreateOnSubmitEvent = {
   id: string;
   type: KeyType;
   privateKey: string;
+  mnemonic: string;
 };
 
 @Component({
@@ -38,7 +39,7 @@ export class CreateComponent implements OnInit {
     this.appSubmit = new EventEmitter();
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void { }
 
   onClickCreateMnemonic() {
     this.appClickCreateMnemonic.emit();
@@ -48,9 +49,9 @@ export class CreateComponent implements OnInit {
     this.appBlurMnemonic.next(mnemonic);
   }
 
-  onSubmit(id: string, type: KeyType, privateKey: string) {
+  onSubmit(id: string, type: KeyType, privateKey: string, mnemonic: string) {
     this.isPasswordVisible = false;
-    this.appSubmit.emit({ id, type, privateKey });
+    this.appSubmit.emit({ id, type, privateKey, mnemonic });
   }
 
   togglePasswordVisibility() {

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.html
@@ -1,6 +1,6 @@
 <mat-stepper orientation="vertical" linear #stepper>
   <mat-step [completed]="saved">
-    <ng-template matStepLabel>Save your Mnemonic</ng-template>
+    <ng-template matStepLabel>Save your mnemonic</ng-template>
     <div class="mb-2">
       <button mat-flat-button class="w-full" color="accent" (click)="saveMnemonic()">
         Download

--- a/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
+++ b/projects/main/src/app/views/keys/key-backup-dialog/key-backup-dialog.component.ts
@@ -34,7 +34,7 @@ export class KeyBackupDialogComponent implements OnInit {
     },
     public matDialogRef: MatDialogRef<KeyBackupDialogComponent>,
     private readonly snackBar: MatSnackBar,
-  ) {}
+  ) { }
 
   onClickSubmit(): void {
     const keyBackupResult: KeyBackupResult = { saved: this.saved, checked: this.checked };
@@ -85,16 +85,16 @@ export class KeyBackupDialogComponent implements OnInit {
   checkSaveMnemonic(str: string): void {
     if (this.mnemonicArray[this.requiredMnemonicNumber] === str) {
       this.checked = true;
-      this.snackBar.open('collect', undefined, {
+      this.snackBar.open('Collect', undefined, {
         duration: 2000,
       });
     } else {
       this.checked = false;
-      this.snackBar.open('wrong mnemonic', undefined, {
-        duration: 300,
+      this.snackBar.open('Wrong mnemonic', undefined, {
+        duration: 1000,
       });
     }
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void { }
 }


### PR DESCRIPTION
・accout作成時のニーモニックを貼り付けてアカウントを作成すると、DLしたファイルのニーモニックが空欄であるバグの修正。
・その他、Blocks画面のタイトル変更。英文の大文字、小文字の整理。
ニーモニックから作成したアカウント（aaaa2）でも、DLしたファイルにニーモニックが記載されていることを確認しました。
[key-aaaaa-2021118213147.txt(オリジナル)](https://github.com/lcnem/telescope/files/7497015/key-aaaaa-2021118213147.txt)
[key-aaaa2-2021118213219.txt(コピー)](https://github.com/lcnem/telescope/files/7497018/key-aaaa2-2021118213219.txt)

動いてはいますが、viewsのcreateコンポーネントからdialogを呼び出した方が素直なような気もしています。
必要であれば修正しますので、コメントお願いいたします。
![IMG20211108215225C](https://user-images.githubusercontent.com/75844498/140745632-50abe54a-2660-426b-a049-e69492d48bf3.jpg)

