### PR TITLE
feat: add error handling to account info page and fix

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -13,6 +13,7 @@
     "zxh404.vscode-proto3",
     "toba.vsfire",
     "bradlc.vscode-tailwindcss",
-    "zxh404.vscode-proto3"
+    "zxh404.vscode-proto3",
+    "streetsidesoftware.code-spell-checker"
   ]
 }

--- a/projects/main/src/app/pages/accounts/account/account.component.html
+++ b/projects/main/src/app/pages/accounts/account/account.component.html
@@ -1,4 +1,4 @@
 <view-account [account]="account$ | async" [balances]="balances$ | async"></view-account>
-<app-vesting></app-vesting>
+<app-distribution></app-distribution>
 <app-staking></app-staking>
 <!--<app-bank></app-bank>-->

--- a/projects/main/src/app/pages/accounts/account/account.component.ts
+++ b/projects/main/src/app/pages/accounts/account/account.component.ts
@@ -2,7 +2,7 @@ import { CosmosSDKService } from '../../../models/cosmos-sdk.service';
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { cosmosclient, rest, proto } from '@cosmos-client/core';
-import { combineLatest, Observable } from 'rxjs';
+import { combineLatest, Observable, of } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 
 @Component({
@@ -11,34 +11,47 @@ import { map, mergeMap } from 'rxjs/operators';
   styleUrls: ['./account.component.css'],
 })
 export class AccountComponent implements OnInit {
-  address$: Observable<cosmosclient.AccAddress>;
+  address$: Observable<cosmosclient.AccAddress | undefined>;
   account$: Observable<proto.cosmos.auth.v1beta1.BaseAccount | unknown | undefined>;
-  balances$: Observable<proto.cosmos.base.v1beta1.ICoin[]>;
+  balances$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
 
   constructor(private route: ActivatedRoute, private cosmosSDK: CosmosSDKService) {
     this.address$ = this.route.params.pipe(
       map((params) => params.address),
-      map((addr) => cosmosclient.AccAddress.fromString(addr)),
+      map((address) => {
+        try {
+          const accAddress = cosmosclient.AccAddress.fromString(address);
+          return accAddress;
+        } catch (error) {
+          return undefined;
+        }
+      }),
     );
 
     const combined$ = combineLatest([this.cosmosSDK.sdk$, this.address$]);
 
     this.account$ = combined$.pipe(
-      mergeMap(([sdk, address]) =>
-        rest.auth
+      mergeMap(([sdk, address]) => {
+        if (address === undefined) {
+          return of(undefined);
+        }
+        return rest.auth
           .account(sdk.rest, address)
           .then((res) => res.data && cosmosclient.codec.unpackCosmosAny(res.data.account))
-          .catch((_) => {
-            console.error(_);
+          .catch((error) => {
+            console.error(error);
             return undefined;
-          }),
-      ),
+          });
+      }),
     );
 
     this.balances$ = combined$.pipe(
-      mergeMap(([sdk, address]) =>
-        rest.bank.allBalances(sdk.rest, address).then((res) => res.data.balances || []),
-      ),
+      mergeMap(([sdk, address]) => {
+        if (address === undefined) {
+          return of([]);
+        }
+        return rest.bank.allBalances(sdk.rest, address).then((res) => res.data.balances || []);
+      }),
     );
   }
 

--- a/projects/main/src/app/pages/accounts/account/account.component.ts
+++ b/projects/main/src/app/pages/accounts/account/account.component.ts
@@ -1,5 +1,6 @@
 import { CosmosSDKService } from '../../../models/cosmos-sdk.service';
 import { Component, OnInit } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute } from '@angular/router';
 import { cosmosclient, rest, proto } from '@cosmos-client/core';
 import { combineLatest, Observable, of } from 'rxjs';
@@ -15,7 +16,11 @@ export class AccountComponent implements OnInit {
   account$: Observable<proto.cosmos.auth.v1beta1.BaseAccount | unknown | undefined>;
   balances$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
 
-  constructor(private route: ActivatedRoute, private cosmosSDK: CosmosSDKService) {
+  constructor(
+    private route: ActivatedRoute,
+    private cosmosSDK: CosmosSDKService,
+    private snackBar: MatSnackBar,
+  ) {
     this.address$ = this.route.params.pipe(
       map((params) => params.address),
       map((address) => {
@@ -23,6 +28,8 @@ export class AccountComponent implements OnInit {
           const accAddress = cosmosclient.AccAddress.fromString(address);
           return accAddress;
         } catch (error) {
+          console.error(error);
+          this.snackBar.open('Invalid address!', undefined, { duration: 3000 });
           return undefined;
         }
       }),

--- a/projects/main/src/app/pages/accounts/account/distribution/distribution.component.html
+++ b/projects/main/src/app/pages/accounts/account/distribution/distribution.component.html
@@ -1,1 +1,1 @@
-<view-distribution [commision]="commision$ | async" [rewards]="rewards$ | async" [slashes]="slashes$ | async"></view-distribution>
+<view-distribution [commission]="commission$ | async" [rewards]="rewards$ | async" [slashes]="slashes$ | async"></view-distribution>

--- a/projects/main/src/app/pages/accounts/account/distribution/distribution.component.ts
+++ b/projects/main/src/app/pages/accounts/account/distribution/distribution.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute } from '@angular/router';
 import { cosmosclient, rest } from '@cosmos-client/core';
 import {
@@ -26,6 +27,7 @@ export class DistributionComponent implements OnInit {
   constructor(
     private readonly route: ActivatedRoute,
     private readonly cosmosSDK: CosmosSDKService,
+    private readonly snackBar: MatSnackBar,
   ) {
     const accAddress$ = this.route.params.pipe(
       map((params) => params.address),
@@ -34,6 +36,8 @@ export class DistributionComponent implements OnInit {
           const accAddress = cosmosclient.AccAddress.fromString(address);
           return accAddress;
         } catch (error) {
+          console.error(error);
+          this.snackBar.open('Invalid address!', undefined, { duration: 3000 });
           return undefined;
         }
       }),

--- a/projects/main/src/app/pages/accounts/account/staking/staking.component.html
+++ b/projects/main/src/app/pages/accounts/account/staking/staking.component.html
@@ -1,1 +1,1 @@
-<view-staking [totalrewards]="totalrewards$ | async"></view-staking>
+<view-staking [totalRewards]="totalRewards$ | async"></view-staking>

--- a/projects/main/src/app/pages/accounts/account/staking/staking.component.ts
+++ b/projects/main/src/app/pages/accounts/account/staking/staking.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute } from '@angular/router';
 import { cosmosclient, rest } from '@cosmos-client/core';
 import {
@@ -23,6 +24,7 @@ export class StakingComponent implements OnInit {
   constructor(
     private readonly route: ActivatedRoute,
     private readonly cosmosSDK: CosmosSDKService,
+    private snackBar: MatSnackBar,
   ) {
     const accAddress$ = this.route.params.pipe(
       map((params) => params.address),
@@ -31,6 +33,8 @@ export class StakingComponent implements OnInit {
           const accAddress = cosmosclient.AccAddress.fromString(address);
           return accAddress;
         } catch (error) {
+          console.error(error);
+          this.snackBar.open('Invalid address!', undefined, { duration: 3000 });
           return undefined;
         }
       }),

--- a/projects/main/src/app/views/accounts/account/distribution/distribution.component.html
+++ b/projects/main/src/app/views/accounts/account/distribution/distribution.component.html
@@ -1,34 +1,34 @@
 <h2>Validator Rewards</h2>
 
-<ng-container *ngIf="commision?.commission?.commission?.[0] === undefined || null ; then empty; else exist">
+<ng-container *ngIf="commission?.commission?.commission?.[0] === undefined || null ; then emptyCommission; else existCommission">
 </ng-container>
 
-<ng-template #empty>
-  <p>{{myType(commision?.commission?.commission?.[0])| json}} </p>
+<ng-template #emptyCommission>
+  <p>{{ myType(commission?.commission?.commission?.[0]) | json }}</p>
   <p>*This account has no commission</p>
 </ng-template>
 
-<ng-template #exist>
-  <p>{{myType(commision?.commission?.commission?.[0])| json}} </p>
+<ng-template #existCommission>
+  <p>{{ myType(commission?.commission?.commission?.[0])| json }}</p>
   <h3>Accumulated Commission</h3>
   <mat-card>
-    <mat-list *ngFor="let com of commision?.commission?.commission">
+    <mat-list *ngFor="let commission of commission?.commission?.commission">
       <mat-list-item>
-        <span>{{ com.amount | number:'1.6-6' }}</span>
+        <span>{{ commission.amount | number:'1.6-6' }}</span>
         <span class="flex-auto"></span>
-        <span>{{ com.denom }}</span>
+        <span>{{ commission.denom }}</span>
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>
     </mat-list>
   </mat-card>
 </ng-template>
 
-<ng-container *ngIf="rewards?.rewards?.rewards?.[0] === undefined; then empty_rewards; else exist_rewards">
+<ng-container *ngIf="rewards?.rewards?.rewards?.[0] === undefined; then emptyRewards; else existRewards">
 </ng-container>
-<ng-template #empty_rewards>
+<ng-template #emptyRewards>
   <p>*This account has no outstanding rewards</p>
 </ng-template>
-<ng-template #exist_rewards>
+<ng-template #existRewards>
   <h3>Outstanding Rewards</h3>
   <mat-card>
     <mat-list *ngFor="let reward of rewards?.rewards?.rewards">
@@ -42,12 +42,12 @@
   </mat-card>
 </ng-template>
 
-<ng-container *ngIf="slashes?.slashes?.[0] === undefined; then empty_slash; else exist_slash">
+<ng-container *ngIf="slashes?.slashes?.[0] === undefined; then emptySlashes; else existSlashes">
 </ng-container>
-<ng-template #empty_slash>
+<ng-template #emptySlashes>
   <p>*This account has no slashes</p>
 </ng-template>
-<ng-template #exist_slash>
+<ng-template #existSlashes>
   <h3>Slashing</h3>
   <mat-card>
     <mat-list *ngFor="let slash of slashes?.slashes">

--- a/projects/main/src/app/views/accounts/account/distribution/distribution.component.html
+++ b/projects/main/src/app/views/accounts/account/distribution/distribution.component.html
@@ -1,15 +1,14 @@
 <h2>Validator Rewards</h2>
 
-<ng-container *ngIf="commission?.commission?.commission?.[0] === undefined || null ; then emptyCommission; else existCommission">
+<ng-container
+  　*ngIf="(commission?.commission?.commission?.length || 0) > 0; then existCommission; else emptyCommission">
 </ng-container>
 
 <ng-template #emptyCommission>
-  <p>{{ myType(commission?.commission?.commission?.[0]) | json }}</p>
   <p>*This account has no commission</p>
 </ng-template>
 
 <ng-template #existCommission>
-  <p>{{ myType(commission?.commission?.commission?.[0])| json }}</p>
   <h3>Accumulated Commission</h3>
   <mat-card>
     <mat-list *ngFor="let commission of commission?.commission?.commission">
@@ -23,7 +22,7 @@
   </mat-card>
 </ng-template>
 
-<ng-container *ngIf="rewards?.rewards?.rewards?.[0] === undefined; then emptyRewards; else existRewards">
+<ng-container *ngIf="(rewards?.rewards?.rewards?.length || 0) > 0; then existRewards; else emptyRewards">
 </ng-container>
 <ng-template #emptyRewards>
   <p>*This account has no outstanding rewards</p>
@@ -42,7 +41,7 @@
   </mat-card>
 </ng-template>
 
-<ng-container *ngIf="slashes?.slashes?.[0] === undefined; then emptySlashes; else existSlashes">
+<ng-container *ngIf="(slashes?.slashes?.length || 0) > 0; then existSlashes; else emptySlashes">
 </ng-container>
 <ng-template #emptySlashes>
   <p>*This account has no slashes</p>

--- a/projects/main/src/app/views/accounts/account/distribution/distribution.component.html
+++ b/projects/main/src/app/views/accounts/account/distribution/distribution.component.html
@@ -1,13 +1,10 @@
 <h2>Validator Rewards</h2>
 
-<ng-container
-  　*ngIf="(commission?.commission?.commission?.length || 0) > 0; then existCommission; else emptyCommission">
+<ng-container *ngIf="(commission?.commission?.commission?.length || 0) > 0; then existCommission; else emptyCommission">
 </ng-container>
-
 <ng-template #emptyCommission>
   <p>*This account has no commission</p>
 </ng-template>
-
 <ng-template #existCommission>
   <h3>Accumulated Commission</h3>
   <mat-card>

--- a/projects/main/src/app/views/accounts/account/distribution/distribution.component.ts
+++ b/projects/main/src/app/views/accounts/account/distribution/distribution.component.ts
@@ -18,13 +18,7 @@ export class DistributionComponent implements OnInit {
   @Input()
   slashes?: CosmosDistributionV1beta1QueryValidatorSlashesResponse | null;
 
-  constructor() {}
+  constructor() { }
 
-  ngOnInit(): void {}
-
-  myType(any: any): any {
-    console.log('comminson', typeof any);
-    console.log('com_json', JSON.stringify(any));
-    return any;
-  }
+  ngOnInit(): void { }
 }

--- a/projects/main/src/app/views/accounts/account/distribution/distribution.component.ts
+++ b/projects/main/src/app/views/accounts/account/distribution/distribution.component.ts
@@ -12,20 +12,19 @@ import {
 })
 export class DistributionComponent implements OnInit {
   @Input()
-  commision?: QueryValidatorCommissionResponseIsTheResponseTypeForTheQueryValidatorCommissionRPCMethod | null;
+  commission?: QueryValidatorCommissionResponseIsTheResponseTypeForTheQueryValidatorCommissionRPCMethod | null;
   @Input()
   rewards?: InlineResponse20047 | null;
   @Input()
   slashes?: CosmosDistributionV1beta1QueryValidatorSlashesResponse | null;
 
-  constructor() { }
+  constructor() {}
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 
   myType(any: any): any {
-
-    console.log("comminson", typeof (any))
-    console.log("com_json", JSON.stringify(any))
-    return any
+    console.log('comminson', typeof any);
+    console.log('com_json', JSON.stringify(any));
+    return any;
   }
 }

--- a/projects/main/src/app/views/accounts/account/staking/staking.component.html
+++ b/projects/main/src/app/views/accounts/account/staking/staking.component.html
@@ -1,48 +1,42 @@
 <h2>Delegator Rewards</h2>
 
-<ng-container *ngIf="totalrewards?.total?.[0] === undefined; then empty_ttl; else exist_ttl">
+<ng-container *ngIf="totalRewards === undefined || null; then emptyTotalRewards; else existTotalRewards">
 </ng-container>
-<ng-template #empty_ttl>
+<ng-template #emptyTotalRewards>
   <p>*This account has no total rewards</p>
 </ng-template>
-<ng-template #exist_ttl>
+<ng-template #existTotalRewards>
   <h3>Total Rewards</h3>
   <mat-card>
-    <mat-list *ngFor="let ttl of totalrewards?.total">
+    <mat-list *ngFor="let eachTotalReward of totalRewards?.total">
       <mat-list-item>
-        <span>{{ ttl.amount | number:'1.6-6' }}</span>
+        <span>{{ eachTotalReward.amount | number:'1.6-6' }}</span>
         <span class="flex-auto"></span>
-        <span>{{ ttl.denom }}</span>
+        <span>{{ eachTotalReward.denom }}</span>
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>
     </mat-list>
   </mat-card>
 </ng-template>
 
-<ng-container *ngIf="totalrewards?.rewards?.[0]  === undefined; then empty_rev; else exist_rev">
+<ng-container *ngIf="totalRewards?.rewards?.[0] === undefined; then emptyEachValidatorRewards; else existEachValidatorRewards">
 </ng-container>
-<ng-template #empty_rev>
+<ng-template #emptyEachValidatorRewards>
   <p>*This account has not received any rewards from validators</p>
 </ng-template>
-<ng-template #exist_rev>
-
-
+<ng-template #existEachValidatorRewards>
   <h3>Rewards by Each Validator</h3>
-  <!--
-delegationTotalRewardsで報酬の合計値、Valaddress毎の報酬の両方を取得可能
-Validate先が多数にならない現状はすべてのValaddress別の報酬の表示をdelegationTotalRewardsで実装
--->
   <mat-card>
-    <mat-list *ngFor="let reward of totalrewards?.rewards">
+    <mat-list *ngFor="let reward of totalRewards?.rewards">
       <mat-list-item>
         <span>Validator Address: </span>
         <span class="flex-auto"></span>
         <span class="ml-2 break-all text-sm sm:text-base">{{ reward.validator_address }}</span>
       </mat-list-item>
-      <mat-list-item *ngFor="let rew of reward?.reward">
-        <span>{{ rew.amount | number:'1.6-6' }}</span>
+      <mat-list-item *ngFor="let eachReward of reward?.reward">
+        <span>{{ eachReward.amount | number:'1.6-6' }}</span>
         <span class="flex-auto"></span>
-        <span>{{ rew.denom }}</span>
+        <span>{{ eachReward.denom }}</span>
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>
     </mat-list>

--- a/projects/main/src/app/views/accounts/account/staking/staking.component.html
+++ b/projects/main/src/app/views/accounts/account/staking/staking.component.html
@@ -1,6 +1,6 @@
 <h2>Delegator Rewards</h2>
 
-<ng-container *ngIf="totalRewards === undefined || null; then emptyTotalRewards; else existTotalRewards">
+<ng-container *ngIf="(totalRewards?.total?.length || 0) > 0; then existTotalRewards; else emptyTotalRewards">
 </ng-container>
 <ng-template #emptyTotalRewards>
   <p>*This account has no total rewards</p>
@@ -19,7 +19,8 @@
   </mat-card>
 </ng-template>
 
-<ng-container *ngIf="totalRewards?.rewards?.[0] === undefined; then emptyEachValidatorRewards; else existEachValidatorRewards">
+<ng-container
+  *ngIf="(totalRewards?.rewards?.length || 0) > 0; then existEachValidatorRewards; else emptyEachValidatorRewards">
 </ng-container>
 <ng-template #emptyEachValidatorRewards>
   <p>*This account has not received any rewards from validators</p>

--- a/projects/main/src/app/views/accounts/account/staking/staking.component.ts
+++ b/projects/main/src/app/views/accounts/account/staking/staking.component.ts
@@ -15,7 +15,7 @@ export class StakingComponent implements OnInit {
     Valaddress指定で取得するAPI delegationRewardsは現状コメントアウト
   */
   @Input()
-  totalrewards?: CosmosDistributionV1beta1QueryDelegationTotalRewardsResponse | null;
+  totalRewards?: CosmosDistributionV1beta1QueryDelegationTotalRewardsResponse | null;
   /*
   @Input()
   eachrewards?: QueryValidatorDelegationsResponseIsResponseTypeForTheQueryValidatorDelegationsRPCMethod | null;

--- a/projects/main/src/app/views/cosmos/staking/validators/validator/validator.component.html
+++ b/projects/main/src/app/views/cosmos/staking/validators/validator/validator.component.html
@@ -61,7 +61,7 @@
     </mat-card-content>
   </mat-card>
 
-  <h3>Commision</h3>
+  <h3>Commission</h3>
   <mat-card>
     <mat-card-content>
       <mat-list>


### PR DESCRIPTION
@taro04 cc: @KimuraYu45z 
https://github.com/lcnem/telescope/pull/197 のプルリクの件、自分だったらこういう方針の修正を考えるという一例としてプルリク作成してみました。レビューして頂き問題無ければマージして、作業進めてくださればと思います。こちらでのデバッグは甘めなので、慎重にレビューしてもらえると助かります。

意図としては、今回気づいてくださったように、クエリパラメーターから与えられるアドレスは、必ずしも有効なアドレスでない場合があり、その場合accAddressに変換するところでエラーが発生していて、そのエラーが適切にハンドリングされていないことは、そもそも根本的に問題であったと思うので、この機会に修正しませんかという意図です。(undefinedなアドレス値をcosmos-client-tsに渡してAPIたたこうとする処理が走ってしまうと、そこで無駄にエラーが起きてしまうでしょうし、もし無効な値をセットしてAPIたたかれる状況等があれば、その分無駄が発生してしまうでしょうし、避けられるなら避けたほうが良いと思います。)

また、(既に書かれたコード、最近のコミット双方ともに)タイポが散見されることから、VSCodeの設定ファイルに推奨extensionとしてcode spell checkerを追加してみました。差分で追加されている拡張機能を入れて、青い波線ついているところは、何かtypoしていないか等、意識してみてください。

また、賛否両論あったりケースバイケースかもしれませんが、エディタの入力補完が便利になった昨今では、変数名を省略してキータイプの手数を減らすよりも、わかりやすい変数名を使ってエディタの入力補完を使用したほうが、コーディングスピードと可読性を両立できるという点で望ましいのではないかと思っています。実装の際にはそういった点も意識してみてください。