### PR TITLE
fix: irregular pagination tx total count 1 page offset 1 page limitation 1 with work around way

### DIFF
--- a/projects/main/src/app/pages/txs/txs.component.ts
+++ b/projects/main/src/app/pages/txs/txs.component.ts
@@ -89,7 +89,8 @@ export class TxsComponent implements OnInit {
       ),
       switchMap(([sdk, selectedTxType, pageSize, pageOffset, _txTotalCount]) => {
         const modifiedPageOffset = pageOffset < 1 ? BigInt(1) : pageOffset;
-        const modifiedPageSize = pageOffset < 1 ? pageOffset + BigInt(pageSize) : BigInt(pageSize);
+        const modifiedPageSize =
+          pageOffset < 1 ? pageOffset + BigInt(pageSize) + BigInt(1) : BigInt(pageSize);
 
         if (modifiedPageOffset <= 0 || modifiedPageSize <= 0) {
           return [];

--- a/projects/main/src/app/pages/txs/txs.component.ts
+++ b/projects/main/src/app/pages/txs/txs.component.ts
@@ -87,10 +87,16 @@ export class TxsComponent implements OnInit {
         ([_sdk, _selectedTxType, _pageSize, _pageOffset, txTotalCount]) =>
           txTotalCount !== BigInt(0),
       ),
-      switchMap(([sdk, selectedTxType, pageSize, pageOffset, _txTotalCount]) => {
+      switchMap(([sdk, selectedTxType, pageSize, pageOffset, txTotalCount]) => {
         const modifiedPageOffset = pageOffset < 1 ? BigInt(1) : pageOffset;
-        const modifiedPageSize =
-          pageOffset < 1 ? pageOffset + BigInt(pageSize) + BigInt(1) : BigInt(pageSize);
+        const modifiedPageSize = pageOffset < 1 ? pageOffset + BigInt(pageSize) : BigInt(pageSize);
+        // Note: This is strange. This is temporary workaround way.
+        const temporaryWorkaroundPageSize =
+          txTotalCount === BigInt(1) &&
+          modifiedPageOffset === BigInt(1) &&
+          modifiedPageSize === BigInt(1)
+            ? modifiedPageSize + BigInt(1)
+            : modifiedPageSize;
 
         if (modifiedPageOffset <= 0 || modifiedPageSize <= 0) {
           return [];
@@ -102,7 +108,7 @@ export class TxsComponent implements OnInit {
             [`message.module='${selectedTxType}'`],
             undefined,
             modifiedPageOffset,
-            modifiedPageSize,
+            temporaryWorkaroundPageSize,
             true,
           )
           .then((res) => {


### PR DESCRIPTION
close #201 

Tx数の少ないもので、`modifiedPageOffset`=`modifiedPageSize`となり、400エラーが返ってくる問題の修正。

pageOffset < 1のとき
変更前
modifiedPageOffset, modifiedPageSize = 1,1

変更後
modifiedPageOffset, modifiedPageSize = 1,2

