### PR TITLE
fix: slash information in account info page

### DIFF
--- a/projects/main/src/app/pages/accounts/account/distribution/distribution.component.html
+++ b/projects/main/src/app/pages/accounts/account/distribution/distribution.component.html
@@ -1,1 +1,3 @@
-<view-distribution [commission]="commission$ | async" [rewards]="rewards$ | async" [slashes]="slashes$ | async"></view-distribution>
+<view-distribution [commission]="commission$ | async" [rewards]="rewards$ | async" [slashes]="slashes$ | async"
+  [displaySize]="displaySize$ | async" [displayNumber]="displayNumber$ | async" [displayLength]="displayLength$ | async"
+  [displaySizeOptions]="displaySizeOptions" (paginationChange)="appPaginationChanged($event)"></view-distribution>

--- a/projects/main/src/app/pages/accounts/account/distribution/distribution.component.ts
+++ b/projects/main/src/app/pages/accounts/account/distribution/distribution.component.ts
@@ -61,8 +61,8 @@ export class DistributionComponent implements OnInit {
           '1',
           latestBlock?.block?.header?.height,
           undefined,
-          undefined,
-          undefined,
+          BigInt(1),
+          BigInt(latestBlock?.block?.header?.height || 2),
           true
         ),
       ),

--- a/projects/main/src/app/pages/accounts/account/distribution/distribution.component.ts
+++ b/projects/main/src/app/pages/accounts/account/distribution/distribution.component.ts
@@ -2,14 +2,16 @@ import { Component, OnInit } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute } from '@angular/router';
 import { cosmosclient, rest } from '@cosmos-client/core';
+import { PageEvent } from '@angular/material/paginator';
 import {
   CosmosDistributionV1beta1QueryValidatorSlashesResponse,
   InlineResponse20047,
   QueryValidatorCommissionResponseIsTheResponseTypeForTheQueryValidatorCommissionRPCMethod,
 } from '@cosmos-client/core/esm/openapi/api';
 import { CosmosSDKService } from 'projects/main/src/app/models/cosmos-sdk.service';
-import { combineLatest, Observable, of } from 'rxjs';
-import { map, mergeMap } from 'rxjs/operators';
+import { BehaviorSubject, of, combineLatest, Observable } from 'rxjs';
+import { map, switchMap, mergeMap } from 'rxjs/operators';
+import { InlineResponse20035 } from '@cosmos-client/core/esm/openapi';
 
 @Component({
   selector: 'app-distribution',
@@ -17,12 +19,21 @@ import { map, mergeMap } from 'rxjs/operators';
   styleUrls: ['./distribution.component.css'],
 })
 export class DistributionComponent implements OnInit {
+  displaySizeOptions = [5, 10, 20, 50, 100];
+  displaySize$: BehaviorSubject<number> = new BehaviorSubject(10);
+  displayNumber$: BehaviorSubject<number> = new BehaviorSubject(1);
+  displayLength$: BehaviorSubject<number> = new BehaviorSubject(0);
+
   commission$: Observable<
     | QueryValidatorCommissionResponseIsTheResponseTypeForTheQueryValidatorCommissionRPCMethod
     | undefined
   >;
   rewards$: Observable<InlineResponse20047 | undefined>;
   slashes$: Observable<CosmosDistributionV1beta1QueryValidatorSlashesResponse | undefined>;
+
+  latestBlock$: Observable<InlineResponse20035 | undefined>;
+  slashingDisplayOffset$: Observable<bigint>;
+  slashesTotalCount$: Observable<bigint>;
 
   constructor(
     private readonly route: ActivatedRoute,
@@ -72,17 +83,73 @@ export class DistributionComponent implements OnInit {
       }),
     );
 
-    this.slashes$ = combined$.pipe(
-      mergeMap(([sdk, accAddress, valAddress]) => {
+    this.latestBlock$ = this.cosmosSDK.sdk$.pipe(
+      mergeMap((sdk) =>
+        rest.tendermint.getLatestBlock(sdk.rest).then((res) => res.data)),
+    );
+
+    this.slashesTotalCount$ = combineLatest([this.cosmosSDK.sdk$, accAddress$, valAddress$, this.latestBlock$]).pipe(
+      switchMap(([sdk, address, valAddress, latestBlock]) => {
+        /*
+        if (valAddress === undefined) {
+          return BigInt(0);
+        }
+        */
+        return rest.distribution
+          .validatorSlashes(
+            sdk.rest,
+            valAddress!,
+            '1',
+            String(latestBlock),
+            undefined,
+            undefined,
+            undefined,
+            true
+          )
+          .then((res) =>
+            res.data.slashes?.length ? BigInt(res.data.slashes?.length) : BigInt(0),
+          )
+      }),
+    );
+
+    this.slashesTotalCount$.subscribe((slashesTotalCount) => {
+      this.displayLength$.next(parseInt(slashesTotalCount.toString()));
+    });
+
+    this.slashingDisplayOffset$ = combineLatest([this.displayNumber$, this.displaySize$, this.displayLength$]).pipe(
+      map(([displayNumber, displaySize, latestBlock]) => {
+        const displayOffset = BigInt(latestBlock) - BigInt(displaySize) * BigInt(displayNumber);
+        return displayOffset;
+      }),
+    );
+
+    this.slashes$ = combineLatest([this.cosmosSDK.sdk$, accAddress$, valAddress$, this.displaySize$, this.displayNumber$, this.displayLength$]).pipe(
+      switchMap(([sdk, accAddress, valAddress, displaySize, displayOffset, latestBlock]) => {
         if (accAddress === undefined || valAddress === undefined) {
           return of(undefined);
         }
+        const modifiedDisplayOffset = displayOffset < 1 ? BigInt(1) : BigInt(displayOffset);
+        const modifiedDisplaySize = displayOffset < 1 ? BigInt(displayOffset) + BigInt(displaySize) : BigInt(displaySize);
         return rest.distribution
-          .validatorSlashes(sdk.rest, valAddress, '1', '2') // Todo: '2' must be fixed to latest block height and add pagination support!
+          .validatorSlashes(
+            sdk.rest,
+            valAddress,
+            '1',
+            String(latestBlock),
+            undefined,
+            modifiedDisplayOffset,
+            modifiedDisplaySize,
+            true
+          )
           .then((res) => res.data);
       }),
     );
   }
 
   ngOnInit(): void { }
+
+  appPaginationChanged(pageEvent: PageEvent): void {
+    this.displaySize$.next(pageEvent.pageSize);
+    this.displayNumber$.next(pageEvent.pageIndex + 1);
+  }
 }

--- a/projects/main/src/app/views/accounts/account/distribution/distribution.component.html
+++ b/projects/main/src/app/views/accounts/account/distribution/distribution.component.html
@@ -38,27 +38,35 @@
   </mat-card>
 </ng-template>
 
+<!-- //debug for add page nation
 <ng-container *ngIf="(slashes?.slashes?.length || 0) > 0; then existSlashes; else emptySlashes">
 </ng-container>
 <ng-template #emptySlashes>
   <p>*This account has no slashes</p>
 </ng-template>
 <ng-template #existSlashes>
-  <h3>Slashing</h3>
-  <mat-card>
-    <mat-list *ngFor="let slash of slashes?.slashes">
-      <mat-list-item>
-        <span>Validator Period:</span>
-        <span class="flex-auto"></span>
-        <span>{{ slash.validator_period }}</span>
-      </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
-      <mat-list-item>
-        <span>Fraction:</span>
-        <span class="flex-auto"></span>
-        <span>{{ slash.fraction }}</span>
-      </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
-    </mat-list>
-  </mat-card>
+-->
+<h3>Slashing</h3>
+<mat-card>
+  <mat-list *ngFor="let slash of slashes?.slashes">
+    <mat-list-item>
+      <span>Validator Period:</span>
+      <span class="flex-auto"></span>
+      <span>{{ slash.validator_period }}</span>
+    </mat-list-item>
+    <mat-divider [inset]="true"></mat-divider>
+    <mat-list-item>
+      <span>Fraction:</span>
+      <span class="flex-auto"></span>
+      <span>{{ slash.fraction }}</span>
+    </mat-list-item>
+    <mat-divider [inset]="true"></mat-divider>
+  </mat-list>
+  <mat-paginator [length]="displayLength" [pageSize]="displaySize" [pageIndex]="displayNumber ? displayNumber - 1 : 0"
+    [pageSizeOptions]="displaySizeOptions ? displaySizeOptions : []" (page)="onPaginationChange($event)">
+  </mat-paginator>
+</mat-card>
+
+<!-- //debug for add page nation
 </ng-template>
+-->

--- a/projects/main/src/app/views/accounts/account/distribution/distribution.component.ts
+++ b/projects/main/src/app/views/accounts/account/distribution/distribution.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { PageEvent } from '@angular/material/paginator';
 import {
   CosmosDistributionV1beta1QueryValidatorSlashesResponse,
   InlineResponse20047,
@@ -17,8 +18,24 @@ export class DistributionComponent implements OnInit {
   rewards?: InlineResponse20047 | null;
   @Input()
   slashes?: CosmosDistributionV1beta1QueryValidatorSlashesResponse | null;
+  @Input()
+  displaySizeOptions?: number[] | null;
+  @Input()
+  displaySize?: number | null;
+  @Input()
+  displayNumber?: number | null;
+  @Input()
+  displayLength?: number | null;
+  @Output()
+  paginationChange: EventEmitter<PageEvent>;
 
-  constructor() { }
+  constructor() {
+    this.paginationChange = new EventEmitter();
+  }
 
   ngOnInit(): void { }
+
+  onPaginationChange(pageEvent: PageEvent): void {
+    this.paginationChange.emit(pageEvent);
+  }
 }


### PR DESCRIPTION
確認と進捗報告のためPR作成します。

// Todo: '2' must be fixed to latest block height  →　完了。

//and add pagination support!　→　すみませんが、こちらがイメージついていません。

このページのslashの部分にページネーションを設定するという認識でしょうか？その場合、キーは何になるのでしょう？
![image](https://user-images.githubusercontent.com/75844498/141473240-1208dd9c-6636-49a5-8dd7-298ecd553927.png)

txsページでslashing確認すると０なので、まだslashingが発生していないと思っています。
簡単に発生させることができるのであれば、デバック用にいくつかデータがあると幸いです。