### PR TITLE
feat: add account delete dialog

### DIFF
--- a/projects/main/src/app/app.module.ts
+++ b/projects/main/src/app/app.module.ts
@@ -2,9 +2,10 @@ import { environment } from '../environments/environment';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { reducers, metaReducers } from './reducers';
-import { KeySelectDialogModule } from './views/keys/key-select-dialog/key-select-dialog.module';
 import { KeyBackupDialogModule } from './views/keys/key-backup-dialog/key-backup-dialog.module';
+import { KeyDeleteConfirmDialogModule } from './views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.module';
 import { KeyDeleteDialogModule } from './views/keys/key-delete-dialog/key-delete-dialog.module';
+import { KeySelectDialogModule } from './views/keys/key-select-dialog/key-select-dialog.module';
 import { ToolbarModule } from './views/toolbar/toolbar.module';
 import { ViewModule } from './views/view.module';
 import { HttpClientModule } from '@angular/common/http';
@@ -36,8 +37,9 @@ import { LoadingDialogModule } from 'ng-loading-dialog';
     KeySelectDialogModule,
     KeyBackupDialogModule,
     KeyDeleteDialogModule,
+    KeyDeleteConfirmDialogModule,
   ],
   providers: [],
   bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}

--- a/projects/main/src/app/app.module.ts
+++ b/projects/main/src/app/app.module.ts
@@ -4,6 +4,7 @@ import { AppComponent } from './app.component';
 import { reducers, metaReducers } from './reducers';
 import { KeySelectDialogModule } from './views/keys/key-select-dialog/key-select-dialog.module';
 import { KeyBackupDialogModule } from './views/keys/key-backup-dialog/key-backup-dialog.module';
+import { KeyDeleteDialogModule } from './views/keys/key-delete-dialog/key-delete-dialog.module';
 import { ToolbarModule } from './views/toolbar/toolbar.module';
 import { ViewModule } from './views/view.module';
 import { HttpClientModule } from '@angular/common/http';
@@ -34,6 +35,7 @@ import { LoadingDialogModule } from 'ng-loading-dialog';
     HttpClientModule,
     KeySelectDialogModule,
     KeyBackupDialogModule,
+    KeyDeleteDialogModule,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/projects/main/src/app/models/keys/key-delete-dialog.service.ts
+++ b/projects/main/src/app/models/keys/key-delete-dialog.service.ts
@@ -1,0 +1,19 @@
+import { KeyDeleteDialogComponent } from '../../views/keys/key-delete-dialog/key-delete-dialog.component';
+import { Injectable } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class KeyDeleteDialogService {
+
+  constructor(private readonly dialog: MatDialog) { }
+
+  openKeyDeleteDialog(id: string) {
+    return this.dialog
+      .open(KeyDeleteDialogComponent, {
+        data: { id: id },
+      })
+      .afterClosed()
+  }
+}

--- a/projects/main/src/app/models/keys/key-delete-dialog.service.ts
+++ b/projects/main/src/app/models/keys/key-delete-dialog.service.ts
@@ -3,17 +3,16 @@ import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class KeyDeleteDialogService {
-
-  constructor(private readonly dialog: MatDialog) { }
+  constructor(private readonly dialog: MatDialog) {}
 
   openKeyDeleteDialog(id: string) {
     return this.dialog
       .open(KeyDeleteDialogComponent, {
         data: { id: id },
       })
-      .afterClosed()
+      .afterClosed();
   }
 }

--- a/projects/main/src/app/models/keys/key.application.service.ts
+++ b/projects/main/src/app/models/keys/key.application.service.ts
@@ -1,9 +1,9 @@
-import { Injectable } from '@angular/core';
-import { LoadingDialogService } from 'ng-loading-dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { Router } from '@angular/router';
 import { KeyType } from './key.model';
 import { KeyService } from './key.service';
+import { Injectable } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { LoadingDialogService } from 'ng-loading-dialog';
 
 @Injectable({
   providedIn: 'root',
@@ -47,7 +47,6 @@ export class KeyApplicationService {
   }
 
   async delete(id: string) {
-
     await this.key.delete(id);
 
     this.snackBar.open('Successfully deleted', undefined, {

--- a/projects/main/src/app/models/keys/key.application.service.ts
+++ b/projects/main/src/app/models/keys/key.application.service.ts
@@ -46,6 +46,17 @@ export class KeyApplicationService {
     await this.router.navigate(['keys', id]);
   }
 
+  async delete(id: string) {
+
+    await this.key.delete(id);
+
+    this.snackBar.open('Successfully deleted', undefined, {
+      duration: 6000,
+    });
+
+    await this.router.navigate(['keys']);
+  }
+
   sign(data: string, privateKey: string): string {
     const uInt8ArrayData = Uint8Array.from(Buffer.from(data, 'base64'));
     const uInt8ArraySignedData = this.key.sign(KeyType.SECP256K1, privateKey, uInt8ArrayData);

--- a/projects/main/src/app/pages/keys/keys.module.ts
+++ b/projects/main/src/app/pages/keys/keys.module.ts
@@ -1,6 +1,5 @@
 import { CreateModule } from '../../views/keys/create/create.module';
 import { GentxModule } from '../../views/keys/gentx/gentx.module';
-import { KeyDeleteConfirmDialogModule } from '../../views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.module';
 import { KeyModule } from '../../views/keys/key/key.module';
 import { KeysModule } from '../../views/keys/keys.module';
 import { SignModule } from '../../views/keys/sign/sign.module';
@@ -23,7 +22,6 @@ import { NgModule } from '@angular/core';
     CreateModule,
     SignModule,
     GentxModule,
-    KeyDeleteConfirmDialogModule,
   ],
 })
 export class AppKeysModule {}

--- a/projects/main/src/app/pages/keys/keys.module.ts
+++ b/projects/main/src/app/pages/keys/keys.module.ts
@@ -1,5 +1,6 @@
 import { CreateModule } from '../../views/keys/create/create.module';
 import { GentxModule } from '../../views/keys/gentx/gentx.module';
+import { KeyDeleteConfirmDialogModule } from '../../views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.module';
 import { KeyModule } from '../../views/keys/key/key.module';
 import { KeysModule } from '../../views/keys/keys.module';
 import { SignModule } from '../../views/keys/sign/sign.module';
@@ -22,6 +23,7 @@ import { NgModule } from '@angular/core';
     CreateModule,
     SignModule,
     GentxModule,
+    KeyDeleteConfirmDialogModule,
   ],
 })
 export class AppKeysModule {}

--- a/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.component.html
@@ -1,0 +1,6 @@
+<p class="font-semibold text-red-500">Will you really delete this account?<br>
+  (You have a private key or a mnemonic, right?)</p>
+<div class="flex">
+  <button mat-flat-button class="w-1/2" color="warn" (click)="confirm()">Yes</button>
+  <button mat-button class="w-1/2" color="primary" (click)="notConfirm()">No</button>
+</div>

--- a/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.component.html
@@ -1,6 +1,9 @@
-<p class="font-semibold text-red-500">Will you really delete this account?<br>
-  (You have a private key or a mnemonic, right?)</p>
+<p class="font-semibold text-red-500">
+  Are you sure you want to delete this account?<br>
+  If you have not backed up this mnemonic or private key,<br>
+  you will never be able to access the account again.
+</p>
 <div class="flex justify-around">
-  <button mat-flat-button class="w-2/5" color="warn" (click)="confirm()">Yes</button>
   <button mat-flat-button class="w-2/5" color="primary" (click)="notConfirm()">No</button>
+  <button mat-flat-button class="w-2/5" color="warn" (click)="confirm()">Yes</button>
 </div>

--- a/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.component.html
@@ -1,6 +1,6 @@
 <p class="font-semibold text-red-500">Will you really delete this account?<br>
   (You have a private key or a mnemonic, right?)</p>
-<div class="flex">
-  <button mat-flat-button class="w-1/2" color="warn" (click)="confirm()">Yes</button>
-  <button mat-button class="w-1/2" color="primary" (click)="notConfirm()">No</button>
+<div class="flex justify-around">
+  <button mat-flat-button class="w-2/5" color="warn" (click)="confirm()">Yes</button>
+  <button mat-flat-button class="w-2/5" color="primary" (click)="notConfirm()">No</button>
 </div>

--- a/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.component.ts
+++ b/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.component.ts
@@ -12,7 +12,6 @@ export class KeyDeleteConfirmDialogComponent implements OnInit {
 
   constructor(
     @Inject(MAT_DIALOG_DATA)
-    //public readonly data: { id: string; },
     public readonly data: {
       id: string;
     },

--- a/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.component.ts
+++ b/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.component.ts
@@ -2,14 +2,12 @@ import { Component, OnInit, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { KeyApplicationService } from 'projects/main/src/app/models/keys/key.application.service';
 
-
 @Component({
   selector: 'app-key-delete-confirm-dialog',
   templateUrl: './key-delete-confirm-dialog.component.html',
-  styleUrls: ['./key-delete-confirm-dialog.component.css']
+  styleUrls: ['./key-delete-confirm-dialog.component.css'],
 })
 export class KeyDeleteConfirmDialogComponent implements OnInit {
-
   constructor(
     @Inject(MAT_DIALOG_DATA)
     public readonly data: {
@@ -17,19 +15,18 @@ export class KeyDeleteConfirmDialogComponent implements OnInit {
     },
     public matDialogRef: MatDialogRef<KeyDeleteConfirmDialogComponent>,
     private readonly keyApplication: KeyApplicationService,
-  ) { }
+  ) {}
 
-  ngOnInit(): void {
-  }
+  ngOnInit(): void {}
 
   confirm(): void {
-    this.keyApplication.delete(this.data.id)
-    this.matDialogRef.close()
+    this.keyApplication.delete(this.data.id);
+    this.matDialogRef.close();
   }
 
   notConfirm(): void {
-    this.matDialogRef.close()
+    this.matDialogRef.close();
   }
 
-  dam() { }
+  dam() {}
 }

--- a/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.component.ts
+++ b/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.component.ts
@@ -27,6 +27,4 @@ export class KeyDeleteConfirmDialogComponent implements OnInit {
   notConfirm(): void {
     this.matDialogRef.close();
   }
-
-  dam() {}
 }

--- a/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.component.ts
+++ b/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.component.ts
@@ -1,0 +1,36 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { KeyApplicationService } from 'projects/main/src/app/models/keys/key.application.service';
+
+
+@Component({
+  selector: 'app-key-delete-confirm-dialog',
+  templateUrl: './key-delete-confirm-dialog.component.html',
+  styleUrls: ['./key-delete-confirm-dialog.component.css']
+})
+export class KeyDeleteConfirmDialogComponent implements OnInit {
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA)
+    //public readonly data: { id: string; },
+    public readonly data: {
+      id: string;
+    },
+    public matDialogRef: MatDialogRef<KeyDeleteConfirmDialogComponent>,
+    private readonly keyApplication: KeyApplicationService,
+  ) { }
+
+  ngOnInit(): void {
+  }
+
+  confirm(): void {
+    this.keyApplication.delete(this.data.id)
+    this.matDialogRef.close()
+  }
+
+  notConfirm(): void {
+    this.matDialogRef.close()
+  }
+
+  dam() { }
+}

--- a/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.module.ts
+++ b/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.module.ts
@@ -7,6 +7,6 @@ import { FormsModule } from '@angular/forms';
 @NgModule({
   declarations: [KeyDeleteConfirmDialogComponent],
   imports: [CommonModule, MaterialModule, FormsModule],
-  exports: [KeyDeleteConfirmDialogComponent]
+  exports: [KeyDeleteConfirmDialogComponent],
 })
-export class KeyDeleteConfirmDialogModule { }
+export class KeyDeleteConfirmDialogModule {}

--- a/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.module.ts
+++ b/projects/main/src/app/views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.module.ts
@@ -1,0 +1,12 @@
+import { MaterialModule } from '../../material.module';
+import { KeyDeleteConfirmDialogComponent } from './key-delete-confirm-dialog.component';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@NgModule({
+  declarations: [KeyDeleteConfirmDialogComponent],
+  imports: [CommonModule, MaterialModule, FormsModule],
+  exports: [KeyDeleteConfirmDialogComponent]
+})
+export class KeyDeleteConfirmDialogModule { }

--- a/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.html
@@ -1,11 +1,12 @@
 <form #formRef="ngForm" (submit)="checkDeleteAccount(inputId)">
-  <ng-template matStepLabel>Check</ng-template>
-  <p>Input your ID</p>
+  <!--<ng-template matStepLabel>Check</ng-template>-->
+  <p>You can delete your account here.<br> If you do not store your private key or mnemonics, the assets of this account
+    will be permanently lost. If you understand this and want to delete your account, please enter your ID.</p>
   <mat-form-field appearance="fill">
     <mat-label>ID</mat-label>
     <input matInput required name="address_name" [(ngModel)]="inputId">
   </mat-form-field>
   <div class="mb-2">
-    <button mat-flat-button class="w-full" color="accent">Delete</button>
+    <button mat-flat-button class="w-full" color="warn">Delete</button>
   </div>
 </form>

--- a/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.html
@@ -1,7 +1,7 @@
 <form #formRef="ngForm" (submit)="checkDeleteAccount(inputId)">
   <p class="p-1 mb-2 rounded border border-red-500">
     You can delete your account here.<br>
-    If you do not store your private key or mnemonics,<br>
+    If you do not backup your private key or mnemonics,<br>
     the assets of this account will be permanently lost.<br>
     If you understand this and want to delete your account,<br>
     please enter your ID.

--- a/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.html
@@ -1,6 +1,10 @@
 <form #formRef="ngForm" (submit)="checkDeleteAccount(inputId)">
-  <p>You can delete your account here.<br> If you do not store your private key or mnemonics, the assets of this account
-    will be permanently lost. If you understand this and want to delete your account, please enter your ID.</p>
+  <p>You can delete your account here.
+    <br> If you do not store your private key or mnemonics,
+    <br>the assets of this account will be permanently lost.
+    <br> If you understand this and want to delete your account,
+    <br> please enter your ID.
+  </p>
   <mat-form-field appearance="fill">
     <mat-label>ID</mat-label>
     <input matInput required name="address_name" [(ngModel)]="inputId">

--- a/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.html
@@ -1,0 +1,11 @@
+<form #formRef="ngForm" (submit)="checkDeleteAccount(inputId)">
+  <ng-template matStepLabel>Check</ng-template>
+  <p>Input your ID</p>
+  <mat-form-field appearance="fill">
+    <mat-label>ID</mat-label>
+    <input matInput required name="address_name" [(ngModel)]="inputId">
+  </mat-form-field>
+  <div class="mb-2">
+    <button mat-flat-button class="w-full" color="accent">Delete</button>
+  </div>
+</form>

--- a/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.html
@@ -1,11 +1,12 @@
 <form #formRef="ngForm" (submit)="checkDeleteAccount(inputId)">
-  <p>You can delete your account here.
-    <br> If you do not store your private key or mnemonics,
-    <br>the assets of this account will be permanently lost.
-    <br> If you understand this and want to delete your account,
-    <br> please enter your ID.
+  <p class="p-1 mb-2 rounded border border-red-500">
+    You can delete your account here.<br>
+    If you do not store your private key or mnemonics,<br>
+    the assets of this account will be permanently lost.<br>
+    If you understand this and want to delete your account,<br>
+    please enter your ID.
   </p>
-  <mat-form-field appearance="fill">
+  <mat-form-field class="w-full" appearance="fill">
     <mat-label>ID</mat-label>
     <input matInput required name="address_name" [(ngModel)]="inputId">
   </mat-form-field>

--- a/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.html
@@ -1,5 +1,4 @@
 <form #formRef="ngForm" (submit)="checkDeleteAccount(inputId)">
-  <!--<ng-template matStepLabel>Check</ng-template>-->
   <p>You can delete your account here.<br> If you do not store your private key or mnemonics, the assets of this account
     will be permanently lost. If you understand this and want to delete your account, please enter your ID.</p>
   <mat-form-field appearance="fill">

--- a/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.ts
+++ b/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { KeyDeleteConfirmDialogComponent } from '../key-delete-confirm-dialog/key-delete-confirm-dialog.component';
+import { MatDialog } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-key-delete-dialog',
@@ -17,6 +19,7 @@ export class KeyDeleteDialogComponent implements OnInit {
       id: string;
     },
     public matDialogRef: MatDialogRef<KeyDeleteDialogComponent>,
+    private readonly dialog: MatDialog,
     private readonly snackBar: MatSnackBar,
   ) { }
 
@@ -25,9 +28,7 @@ export class KeyDeleteDialogComponent implements OnInit {
 
   checkDeleteAccount(id: string) {
     if (id === this.data.id) {
-      this.snackBar.open('Collect ID', undefined, {
-        duration: 2000,
-      });
+      this.openKeyDeleteConfirmDialog()
     } else {
       this.snackBar.open('Wrong ID', undefined, {
         duration: 2000,
@@ -35,4 +36,13 @@ export class KeyDeleteDialogComponent implements OnInit {
     }
   }
 
+  openKeyDeleteConfirmDialog() {
+    this.dialog.open(KeyDeleteConfirmDialogComponent, {
+      data: { id: this.data.id },
+    })
+      .afterClosed()
+      .subscribe((_) => {
+        this.matDialogRef.close()
+      })
+  }
 }

--- a/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.ts
+++ b/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.ts
@@ -1,0 +1,38 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Component({
+  selector: 'app-key-delete-dialog',
+  templateUrl: './key-delete-dialog.component.html',
+  styleUrls: ['./key-delete-dialog.component.css']
+})
+export class KeyDeleteDialogComponent implements OnInit {
+
+  inputId = ""
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA)
+    public readonly data: {
+      id: string;
+    },
+    public matDialogRef: MatDialogRef<KeyDeleteDialogComponent>,
+    private readonly snackBar: MatSnackBar,
+  ) { }
+
+  ngOnInit(): void {
+  }
+
+  checkDeleteAccount(id: string) {
+    if (id === this.data.id) {
+      this.snackBar.open('Collect ID', undefined, {
+        duration: 2000,
+      });
+    } else {
+      this.snackBar.open('Wrong ID', undefined, {
+        duration: 2000,
+      });
+    }
+  }
+
+}

--- a/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.ts
+++ b/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.component.ts
@@ -1,17 +1,16 @@
+import { KeyDeleteConfirmDialogComponent } from '../key-delete-confirm-dialog/key-delete-confirm-dialog.component';
 import { Component, OnInit, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { KeyDeleteConfirmDialogComponent } from '../key-delete-confirm-dialog/key-delete-confirm-dialog.component';
 import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-key-delete-dialog',
   templateUrl: './key-delete-dialog.component.html',
-  styleUrls: ['./key-delete-dialog.component.css']
+  styleUrls: ['./key-delete-dialog.component.css'],
 })
 export class KeyDeleteDialogComponent implements OnInit {
-
-  inputId = ""
+  inputId = '';
 
   constructor(
     @Inject(MAT_DIALOG_DATA)
@@ -21,14 +20,13 @@ export class KeyDeleteDialogComponent implements OnInit {
     public matDialogRef: MatDialogRef<KeyDeleteDialogComponent>,
     private readonly dialog: MatDialog,
     private readonly snackBar: MatSnackBar,
-  ) { }
+  ) {}
 
-  ngOnInit(): void {
-  }
+  ngOnInit(): void {}
 
   checkDeleteAccount(id: string) {
     if (id === this.data.id) {
-      this.openKeyDeleteConfirmDialog()
+      this.openKeyDeleteConfirmDialog();
     } else {
       this.snackBar.open('Wrong ID', undefined, {
         duration: 2000,
@@ -37,12 +35,13 @@ export class KeyDeleteDialogComponent implements OnInit {
   }
 
   openKeyDeleteConfirmDialog() {
-    this.dialog.open(KeyDeleteConfirmDialogComponent, {
-      data: { id: this.data.id },
-    })
+    this.dialog
+      .open(KeyDeleteConfirmDialogComponent, {
+        data: { id: this.data.id },
+      })
       .afterClosed()
       .subscribe((_) => {
-        this.matDialogRef.close()
-      })
+        this.matDialogRef.close();
+      });
   }
 }

--- a/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.module.ts
+++ b/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.module.ts
@@ -1,0 +1,12 @@
+import { MaterialModule } from '../../material.module';
+import { KeyDeleteDialogComponent } from './key-delete-dialog.component';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@NgModule({
+  declarations: [KeyDeleteDialogComponent],
+  imports: [CommonModule, MaterialModule, FormsModule],
+  exports: [KeyDeleteDialogComponent],
+})
+export class KeyDeleteDialogModule { }

--- a/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.module.ts
+++ b/projects/main/src/app/views/keys/key-delete-dialog/key-delete-dialog.module.ts
@@ -9,4 +9,4 @@ import { FormsModule } from '@angular/forms';
   imports: [CommonModule, MaterialModule, FormsModule],
   exports: [KeyDeleteDialogComponent],
 })
-export class KeyDeleteDialogModule { }
+export class KeyDeleteDialogModule {}

--- a/projects/main/src/app/views/keys/key/key.component.html
+++ b/projects/main/src/app/views/keys/key/key.component.html
@@ -3,7 +3,7 @@
     <span>{{ key?.id }}</span>
     <span class="flex-auto"></span>
     <button (click)="openDeleteDialog(key?.id || '')" color="accent">
-      <mat-icon color="accent">delete</mat-icon>
+      <mat-icon color="warn">delete</mat-icon>
     </button>
   </div>
 </h2>

--- a/projects/main/src/app/views/keys/key/key.component.html
+++ b/projects/main/src/app/views/keys/key/key.component.html
@@ -1,4 +1,12 @@
-<h2>{{ key?.id }}</h2>
+<h2>
+  <div class="flex flex-row">
+    <span>{{ key?.id }}</span>
+    <span class="flex-auto"></span>
+    <button (click)="openDeleteDialog(key?.id || '')" color="accent">
+      <mat-icon color="accent">delete</mat-icon>
+    </button>
+  </div>
+</h2>
 
 <mat-list>
   <mat-card>

--- a/projects/main/src/app/views/keys/key/key.component.ts
+++ b/projects/main/src/app/views/keys/key/key.component.ts
@@ -1,6 +1,7 @@
 import { Key } from '../../../models/keys/key.model';
 import { Component, OnInit, Input } from '@angular/core';
 import { cosmosclient } from '@cosmos-client/core';
+import { KeyDeleteDialogService } from '../../../models/keys/key-delete-dialog.service';
 
 @Component({
   selector: 'view-key',
@@ -20,15 +21,21 @@ export class KeyComponent implements OnInit {
   @Input()
   faucets?:
     | {
-        hasFaucet: boolean;
-        faucetURL: string;
-        denom: string;
-        creditAmount: number;
-        maxCredit: number;
-      }[]
+      hasFaucet: boolean;
+      faucetURL: string;
+      denom: string;
+      creditAmount: number;
+      maxCredit: number;
+    }[]
     | null;
 
-  constructor() {}
+  constructor(
+    private readonly keyDeleteDialogService: KeyDeleteDialogService,
+  ) { }
 
-  ngOnInit(): void {}
+  ngOnInit(): void { }
+
+  openDeleteDialog(id: string) {
+    this.keyDeleteDialogService.openKeyDeleteDialog(id)
+  }
 }

--- a/projects/main/src/app/views/keys/key/key.component.ts
+++ b/projects/main/src/app/views/keys/key/key.component.ts
@@ -1,7 +1,7 @@
+import { KeyDeleteDialogService } from '../../../models/keys/key-delete-dialog.service';
 import { Key } from '../../../models/keys/key.model';
 import { Component, OnInit, Input } from '@angular/core';
 import { cosmosclient } from '@cosmos-client/core';
-import { KeyDeleteDialogService } from '../../../models/keys/key-delete-dialog.service';
 
 @Component({
   selector: 'view-key',
@@ -21,21 +21,19 @@ export class KeyComponent implements OnInit {
   @Input()
   faucets?:
     | {
-      hasFaucet: boolean;
-      faucetURL: string;
-      denom: string;
-      creditAmount: number;
-      maxCredit: number;
-    }[]
+        hasFaucet: boolean;
+        faucetURL: string;
+        denom: string;
+        creditAmount: number;
+        maxCredit: number;
+      }[]
     | null;
 
-  constructor(
-    private readonly keyDeleteDialogService: KeyDeleteDialogService,
-  ) { }
+  constructor(private readonly keyDeleteDialogService: KeyDeleteDialogService) {}
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 
   openDeleteDialog(id: string) {
-    this.keyDeleteDialogService.openKeyDeleteDialog(id)
+    this.keyDeleteDialogService.openKeyDeleteDialog(id);
   }
 }


### PR DESCRIPTION
製作途中ですが、進捗報告かねPR作成します。作成したアカウント機能の追加タスクです。
・/keys/:key_idページの上端右端にDeleteボタンを追加。
　（このボタンはあえてゴミ箱のアイコンだけにしています。さすがに分かりにくいでしょうか？
　　そうであればCreateと同じようにflatボタン＋iconに修正します。）
・アカウント削除ダイアログ追加。
・idの判定と判定結果のスナックバー表示追加
![image](https://user-images.githubusercontent.com/75844498/141993235-72d243e8-7ca4-4a7f-8a4c-14750eb11b9e.png)
明日以降実際のアカウント削除の実装をします。