### PR TITLE
feat: bank send tx error handling and improve ui ux

### DIFF
--- a/projects/main/src/app/models/cosmos/bank.application.service.ts
+++ b/projects/main/src/app/models/cosmos/bank.application.service.ts
@@ -20,18 +20,18 @@ export class BankApplicationService {
   async send(
     key: Key,
     toAddress: string,
-    amount: proto.cosmos.base.v1beta1.ICoin[],
+    coins: proto.cosmos.base.v1beta1.ICoin[],
     privateKey: string,
   ) {
     const dialogRef = this.loadingDialog.open('Sending');
-    let txhash: string;
+    let txhash: string | undefined;
 
     try {
-      const res: any = await this.bank.send(key, toAddress, amount, privateKey);
-      if (res.data.tx_response.code !== 0 && res.data.tx_response.raw_log !== undefined) {
-        throw new Error(res.data.tx_response.raw_log);
+      const res = await this.bank.send(key, toAddress, coins, privateKey);
+      txhash = res.tx_response?.txhash;
+      if (txhash === undefined) {
+        throw Error('Invalid txhash!');
       }
-      txhash = res.data.tx_response.txhash;
     } catch (error) {
       const msg = (error as Error).toString();
       this.snackBar.open(`Error has occured: ${msg}`, undefined, {

--- a/projects/main/src/app/models/cosmos/bank.application.service.ts
+++ b/projects/main/src/app/models/cosmos/bank.application.service.ts
@@ -27,9 +27,14 @@ export class BankApplicationService {
     let txhash: string;
 
     try {
-      txhash = await this.bank.send(key, toAddress, amount, privateKey);
-    } catch {
-      this.snackBar.open('Error has occured', undefined, {
+      const res: any = await this.bank.send(key, toAddress, amount, privateKey);
+      if (res.data.tx_response.code !== 0 && res.data.tx_response.raw_log !== undefined) {
+        throw new Error(res.data.tx_response.raw_log);
+      }
+      txhash = res.data.tx_response.txhash;
+    } catch (error) {
+      const msg = (error as Error).toString();
+      this.snackBar.open(`Error has occured: ${msg}`, undefined, {
         duration: 6000,
       });
       return;

--- a/projects/main/src/app/models/cosmos/bank.application.service.ts
+++ b/projects/main/src/app/models/cosmos/bank.application.service.ts
@@ -20,14 +20,14 @@ export class BankApplicationService {
   async send(
     key: Key,
     toAddress: string,
-    coins: proto.cosmos.base.v1beta1.ICoin[],
+    amount: proto.cosmos.base.v1beta1.ICoin[],
     privateKey: string,
   ) {
     const dialogRef = this.loadingDialog.open('Sending');
     let txhash: string | undefined;
 
     try {
-      const res = await this.bank.send(key, toAddress, coins, privateKey);
+      const res = await this.bank.send(key, toAddress, amount, privateKey);
       txhash = res.tx_response?.txhash;
       if (txhash === undefined) {
         throw Error('Invalid txhash!');

--- a/projects/main/src/app/models/cosmos/bank.service.ts
+++ b/projects/main/src/app/models/cosmos/bank.service.ts
@@ -69,6 +69,6 @@ export class BankService {
       mode: rest.tx.BroadcastTxMode.Block,
     });
 
-    return result.data.tx_response?.txhash || '';
+    return result || '';
   }
 }

--- a/projects/main/src/app/models/cosmos/bank.service.ts
+++ b/projects/main/src/app/models/cosmos/bank.service.ts
@@ -14,7 +14,7 @@ export class BankService {
   async send(
     key: Key,
     toAddress: string,
-    coins: proto.cosmos.base.v1beta1.ICoin[],
+    amount: proto.cosmos.base.v1beta1.ICoin[],
     privateKey: string,
   ): Promise<InlineResponse20075> {
     const sdk = await this.cosmosSDK.sdk().then((sdk) => sdk.rest);
@@ -36,7 +36,7 @@ export class BankService {
     const msgSend = new proto.cosmos.bank.v1beta1.MsgSend({
       from_address: fromAddress.toString(),
       to_address: toAddress,
-      amount: coins,
+      amount: amount,
     });
 
     const txBody = new proto.cosmos.tx.v1beta1.TxBody({

--- a/projects/main/src/app/models/cosmos/bank.service.ts
+++ b/projects/main/src/app/models/cosmos/bank.service.ts
@@ -3,6 +3,7 @@ import { Key } from '../keys/key.model';
 import { KeyService } from '../keys/key.service';
 import { Injectable } from '@angular/core';
 import { cosmosclient, rest, proto } from '@cosmos-client/core';
+import { InlineResponse20075 } from '@cosmos-client/core/esm/openapi';
 
 @Injectable({
   providedIn: 'root',
@@ -13,9 +14,9 @@ export class BankService {
   async send(
     key: Key,
     toAddress: string,
-    amount: proto.cosmos.base.v1beta1.ICoin[],
+    coins: proto.cosmos.base.v1beta1.ICoin[],
     privateKey: string,
-  ) {
+  ): Promise<InlineResponse20075> {
     const sdk = await this.cosmosSDK.sdk().then((sdk) => sdk.rest);
     const privKey = this.key.getPrivKey(key.type, privateKey);
     const pubKey = privKey.pubKey();
@@ -35,7 +36,7 @@ export class BankService {
     const msgSend = new proto.cosmos.bank.v1beta1.MsgSend({
       from_address: fromAddress.toString(),
       to_address: toAddress,
-      amount,
+      amount: coins,
     });
 
     const txBody = new proto.cosmos.tx.v1beta1.TxBody({
@@ -69,6 +70,11 @@ export class BankService {
       mode: rest.tx.BroadcastTxMode.Block,
     });
 
-    return result || '';
+    // check error
+    if (result.data.tx_response?.code !== 0) {
+      throw Error(result.data.tx_response?.raw_log);
+    }
+
+    return result.data;
   }
 }

--- a/projects/main/src/app/pages/cosmos/bank/send/send.component.html
+++ b/projects/main/src/app/pages/cosmos/bank/send/send.component.html
@@ -1,5 +1,6 @@
 <view-send
   [key]="key$ | async"
   [coins]="coins$ | async"
+  [amount]="amount$ | async"
   (appSubmit)="onSubmit($event)"
 ></view-send>

--- a/projects/main/src/app/pages/cosmos/bank/send/send.component.html
+++ b/projects/main/src/app/pages/cosmos/bank/send/send.component.html
@@ -1,6 +1,6 @@
 <view-send
   [key]="key$ | async"
   [coins]="coins$ | async"
-  [amount]="amount$ | async"
+  [amounts]="amounts$ | async"
   (appSubmit)="onSubmit($event)"
 ></view-send>

--- a/projects/main/src/app/pages/cosmos/bank/send/send.component.html
+++ b/projects/main/src/app/pages/cosmos/bank/send/send.component.html
@@ -1,6 +1,6 @@
 <view-send
   [key]="key$ | async"
   [coins]="coins$ | async"
-  [sentCoins]="sentCoins$ | async"
+  [amount]="amount$ | async"
   (appSubmit)="onSubmit($event)"
 ></view-send>

--- a/projects/main/src/app/pages/cosmos/bank/send/send.component.html
+++ b/projects/main/src/app/pages/cosmos/bank/send/send.component.html
@@ -1,6 +1,6 @@
 <view-send
   [key]="key$ | async"
   [coins]="coins$ | async"
-  [amounts]="amounts$ | async"
+  [sentCoins]="sentCoins$ | async"
   (appSubmit)="onSubmit($event)"
 ></view-send>

--- a/projects/main/src/app/pages/cosmos/bank/send/send.component.ts
+++ b/projects/main/src/app/pages/cosmos/bank/send/send.component.ts
@@ -17,7 +17,7 @@ import { map, mergeMap, filter, tap } from 'rxjs/operators';
 export class SendComponent implements OnInit {
   key$: Observable<Key | undefined>;
   coins$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
-  sentCoins$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
+  amount$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
 
   constructor(
     private readonly cosmosSDK: CosmosSDKService,
@@ -39,9 +39,9 @@ export class SendComponent implements OnInit {
       map((result) => result.data.balances),
     );
 
-    this.sentCoins$ = this.coins$.pipe(
-      map((coins) =>
-        coins?.map((coin) => ({
+    this.amount$ = this.coins$.pipe(
+      map((amount) =>
+        amount?.map((coin) => ({
           denom: coin.denom,
           amount: '0',
         })),
@@ -52,6 +52,6 @@ export class SendComponent implements OnInit {
   ngOnInit(): void {}
 
   async onSubmit($event: SendOnSubmitEvent) {
-    await this.bankApplication.send($event.key, $event.toAddress, $event.coins, $event.privateKey);
+    await this.bankApplication.send($event.key, $event.toAddress, $event.amount, $event.privateKey);
   }
 }

--- a/projects/main/src/app/pages/cosmos/bank/send/send.component.ts
+++ b/projects/main/src/app/pages/cosmos/bank/send/send.component.ts
@@ -17,7 +17,7 @@ import { map, mergeMap, filter, tap } from 'rxjs/operators';
 export class SendComponent implements OnInit {
   key$: Observable<Key | undefined>;
   coins$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
-  amount$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
+  amounts$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
   constructor(
     private readonly cosmosSDK: CosmosSDKService,
     private readonly key: KeyService,
@@ -38,7 +38,7 @@ export class SendComponent implements OnInit {
       map((result) => result.data.balances),
     );
 
-    this.amount$ = this.coins$.pipe(
+    this.amounts$ = this.coins$.pipe(
       map((coin) =>
         coin?.map((data) => ({
           denom: data.denom,

--- a/projects/main/src/app/pages/cosmos/bank/send/send.component.ts
+++ b/projects/main/src/app/pages/cosmos/bank/send/send.component.ts
@@ -17,7 +17,8 @@ import { map, mergeMap, filter, tap } from 'rxjs/operators';
 export class SendComponent implements OnInit {
   key$: Observable<Key | undefined>;
   coins$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
-  amounts$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
+  sentCoins$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
+
   constructor(
     private readonly cosmosSDK: CosmosSDKService,
     private readonly key: KeyService,
@@ -38,7 +39,7 @@ export class SendComponent implements OnInit {
       map((result) => result.data.balances),
     );
 
-    this.amounts$ = this.coins$.pipe(
+    this.sentCoins$ = this.coins$.pipe(
       map((coin) =>
         coin?.map((data) => ({
           denom: data.denom,
@@ -51,6 +52,6 @@ export class SendComponent implements OnInit {
   ngOnInit(): void {}
 
   async onSubmit($event: SendOnSubmitEvent) {
-    await this.bankApplication.send($event.key, $event.toAddress, $event.amount, $event.privateKey);
+    await this.bankApplication.send($event.key, $event.toAddress, $event.coins, $event.privateKey);
   }
 }

--- a/projects/main/src/app/pages/cosmos/bank/send/send.component.ts
+++ b/projects/main/src/app/pages/cosmos/bank/send/send.component.ts
@@ -17,6 +17,7 @@ import { map, mergeMap, filter, tap } from 'rxjs/operators';
 export class SendComponent implements OnInit {
   key$: Observable<Key | undefined>;
   coins$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
+  amount$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
   constructor(
     private readonly cosmosSDK: CosmosSDKService,
     private readonly key: KeyService,
@@ -35,6 +36,15 @@ export class SendComponent implements OnInit {
     this.coins$ = combineLatest([this.cosmosSDK.sdk$, address$]).pipe(
       mergeMap(([sdk, address]) => rest.bank.allBalances(sdk.rest, address)),
       map((result) => result.data.balances),
+    );
+
+    this.amount$ = this.coins$.pipe(
+      map((coin) =>
+        coin?.map((data) => ({
+          denom: data.denom,
+          amount: '0',
+        })),
+      ),
     );
   }
 

--- a/projects/main/src/app/pages/cosmos/bank/send/send.component.ts
+++ b/projects/main/src/app/pages/cosmos/bank/send/send.component.ts
@@ -40,9 +40,9 @@ export class SendComponent implements OnInit {
     );
 
     this.sentCoins$ = this.coins$.pipe(
-      map((coin) =>
-        coin?.map((data) => ({
-          denom: data.denom,
+      map((coins) =>
+        coins?.map((coin) => ({
+          denom: coin.denom,
           amount: '0',
         })),
       ),

--- a/projects/main/src/app/views/cosmos/bank/send/send.component.html
+++ b/projects/main/src/app/views/cosmos/bank/send/send.component.html
@@ -24,12 +24,12 @@
       <input #toAddressRef ngModel name="to-address" matInput required />
     </mat-form-field>
 
-    <ng-container *ngFor="let e of sentCoins; let i = index">
+    <ng-container *ngFor="let e of amount; let i = index">
       <div class="flex flex-row content-center items-center">
         <mat-form-field class="flex-auto">
           <mat-label>Denom</mat-label>
           <input
-            [(ngModel)]="sentCoins && sentCoins[i].denom"
+            [(ngModel)]="amount && amount[i].denom"
             name="denom-{{ i }}"
             type="text"
             matInput
@@ -39,7 +39,7 @@
         <mat-form-field class="flex-auto">
           <mat-label>Amount</mat-label>
           <input
-            [(ngModel)]="sentCoins && sentCoins[i].amount"
+            [(ngModel)]="amount && amount[i].amount"
             name="amount-{{ i }}"
             matInput
             type="number"

--- a/projects/main/src/app/views/cosmos/bank/send/send.component.html
+++ b/projects/main/src/app/views/cosmos/bank/send/send.component.html
@@ -24,37 +24,32 @@
       <input #toAddressRef ngModel name="to-address" matInput required />
     </mat-form-field>
 
-    <ng-template #enable>
-      <ng-container *ngFor="let e of amount; let i = index">
-        <ng-container
-          *ngIf="amount[i] !== null || undefined; then enable; else disable"
-        ></ng-container>
-        <div class="flex flex-row content-center items-center">
-          <mat-form-field class="flex-auto">
-            <mat-label>Denom</mat-label>
-            <input
-              [(ngModel)]="amount[i].denom"
-              name="denom-{{ i }}"
-              type="text"
-              matInput
-              readonly
-            />
-          </mat-form-field>
-          <mat-form-field class="flex-auto">
-            <mat-label>Amount</mat-label>
-            <input
-              [(ngModel)]="amount[i].amount"
-              name="amount-{{ i }}"
-              matInput
-              type="number"
-              pattern="^\d+$"
-              [min]="0"
-              required
-            />
-          </mat-form-field>
-        </div>
-      </ng-container>
-    </ng-template>
+    <ng-container *ngFor="let e of amounts; let i = index">
+      <div class="flex flex-row content-center items-center">
+        <mat-form-field class="flex-auto">
+          <mat-label>Denom</mat-label>
+          <input
+            [(ngModel)]="amounts && amounts[i].denom"
+            name="denom-{{ i }}"
+            type="text"
+            matInput
+            readonly
+          />
+        </mat-form-field>
+        <mat-form-field class="flex-auto">
+          <mat-label>Amount</mat-label>
+          <input
+            [(ngModel)]="amounts && amounts[i].amount"
+            name="amount-{{ i }}"
+            matInput
+            type="number"
+            pattern="^\d+$"
+            [min]="0"
+            required
+          />
+        </mat-form-field>
+      </div>
+    </ng-container>
 
     <mat-form-field class="w-full">
       <mat-label>ID</mat-label>

--- a/projects/main/src/app/views/cosmos/bank/send/send.component.html
+++ b/projects/main/src/app/views/cosmos/bank/send/send.component.html
@@ -29,14 +29,29 @@
       <div class="flex flex-row content-center items-center">
         <mat-form-field class="flex-auto">
           <mat-label>Denom</mat-label>
-          <input [(ngModel)]="amount[i].denom" name="denom-{{ i }}" matInput />
+          <mat-select [(ngModel)]="amount[i].denom" name="denom-{{ i }}">
+            <mat-option *ngFor="let token of tokens" [value]="token.value">
+              {{ token.viewValue }}
+            </mat-option>
+          </mat-select>
         </mat-form-field>
         <mat-form-field class="flex-auto">
           <mat-label>Amount</mat-label>
-          <input [(ngModel)]="amount[i].amount" name="amount-{{ i }}" matInput type="number" pattern="^\d+$"
-            [min]="0" />
+          <input
+            [(ngModel)]="amount[i].amount"
+            name="amount-{{ i }}"
+            matInput
+            type="number"
+            pattern="^\d+$"
+            [min]="0"
+          />
         </mat-form-field>
-        <button mat-icon-button color="warn" [disabled]="amount.length <= 1" (click)="removeAmount(i)">
+        <button
+          mat-icon-button
+          color="warn"
+          [disabled]="amount.length <= 1"
+          (click)="removeAmount(i)"
+        >
           <mat-icon>close</mat-icon>
         </button>
       </div>
@@ -45,16 +60,30 @@
       <mat-icon>add</mat-icon>
       <span>Add</span>
     </button>
-    <mat-checkbox required>Confirm</mat-checkbox>
 
     <mat-form-field class="w-full">
       <mat-label>ID</mat-label>
-      <input #idRef type="text" name="id" [ngModel]="key?.id" autocomplete="username" matInput readonly />
+      <input
+        #idRef
+        type="text"
+        name="id"
+        [ngModel]="key?.id"
+        autocomplete="username"
+        matInput
+        readonly
+      />
     </mat-form-field>
     <mat-form-field class="w-full">
       <mat-label>Private key</mat-label>
-      <input #privateKeyRef ngModel type="password" name="privateKey" autocomplete="current-password" matInput
-        required />
+      <input
+        #privateKeyRef
+        ngModel
+        type="password"
+        name="privateKey"
+        autocomplete="current-password"
+        matInput
+        required
+      />
     </mat-form-field>
     <button mat-flat-button color="accent" [disabled]="formRef.invalid">Send</button>
   </form>

--- a/projects/main/src/app/views/cosmos/bank/send/send.component.html
+++ b/projects/main/src/app/views/cosmos/bank/send/send.component.html
@@ -18,48 +18,43 @@
       <mat-divider></mat-divider>
     </ng-container>
   </mat-list>
-
   <form #formRef="ngForm" (submit)="onSubmit(toAddressRef.value, privateKeyRef.value)">
     <mat-form-field class="w-full">
       <mat-label>To address</mat-label>
       <input #toAddressRef ngModel name="to-address" matInput required />
     </mat-form-field>
 
-    <ng-container *ngFor="let e of amount; let i = index">
-      <div class="flex flex-row content-center items-center">
-        <mat-form-field class="flex-auto">
-          <mat-label>Denom</mat-label>
-          <mat-select [(ngModel)]="amount[i].denom" name="denom-{{ i }}">
-            <mat-option *ngFor="let token of tokens" [value]="token.value">
-              {{ token.viewValue }}
-            </mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field class="flex-auto">
-          <mat-label>Amount</mat-label>
-          <input
-            [(ngModel)]="amount[i].amount"
-            name="amount-{{ i }}"
-            matInput
-            type="number"
-            pattern="^\d+$"
-            [min]="0"
-          />
-        </mat-form-field>
-        <button
-          mat-icon-button
-          color="warn"
-          [disabled]="amount.length <= 1"
-          (click)="removeAmount(i)"
-        >
-          <mat-icon>close</mat-icon>
-        </button>
-      </div>
-    </ng-container>
-    <button mat-button class="w-full" color="accent" (click)="addAmount()">
-      <mat-icon>add</mat-icon>
-      <span>Add</span>
-    </button>
+    <ng-template #enable>
+      <ng-container *ngFor="let e of amount; let i = index">
+        <ng-container
+          *ngIf="amount[i] !== null || undefined; then enable; else disable"
+        ></ng-container>
+        <div class="flex flex-row content-center items-center">
+          <mat-form-field class="flex-auto">
+            <mat-label>Denom</mat-label>
+            <input
+              [(ngModel)]="amount[i].denom"
+              name="denom-{{ i }}"
+              type="text"
+              matInput
+              readonly
+            />
+          </mat-form-field>
+          <mat-form-field class="flex-auto">
+            <mat-label>Amount</mat-label>
+            <input
+              [(ngModel)]="amount[i].amount"
+              name="amount-{{ i }}"
+              matInput
+              type="number"
+              pattern="^\d+$"
+              [min]="0"
+              required
+            />
+          </mat-form-field>
+        </div>
+      </ng-container>
+    </ng-template>
 
     <mat-form-field class="w-full">
       <mat-label>ID</mat-label>
@@ -90,4 +85,8 @@
 </ng-template>
 <ng-template #empty>
   <p>Balance is empty</p>
+</ng-template>
+
+<ng-template #disable>
+  <p>Send is disable</p>
 </ng-template>

--- a/projects/main/src/app/views/cosmos/bank/send/send.component.html
+++ b/projects/main/src/app/views/cosmos/bank/send/send.component.html
@@ -24,12 +24,12 @@
       <input #toAddressRef ngModel name="to-address" matInput required />
     </mat-form-field>
 
-    <ng-container *ngFor="let e of amounts; let i = index">
+    <ng-container *ngFor="let e of sentCoins; let i = index">
       <div class="flex flex-row content-center items-center">
         <mat-form-field class="flex-auto">
           <mat-label>Denom</mat-label>
           <input
-            [(ngModel)]="amounts && amounts[i].denom"
+            [(ngModel)]="sentCoins && sentCoins[i].denom"
             name="denom-{{ i }}"
             type="text"
             matInput
@@ -39,7 +39,7 @@
         <mat-form-field class="flex-auto">
           <mat-label>Amount</mat-label>
           <input
-            [(ngModel)]="amounts && amounts[i].amount"
+            [(ngModel)]="sentCoins && sentCoins[i].amount"
             name="amount-{{ i }}"
             matInput
             type="number"

--- a/projects/main/src/app/views/cosmos/bank/send/send.component.ts
+++ b/projects/main/src/app/views/cosmos/bank/send/send.component.ts
@@ -5,7 +5,7 @@ import { proto } from '@cosmos-client/core';
 export type SendOnSubmitEvent = {
   key: Key;
   toAddress: string;
-  amount: proto.cosmos.base.v1beta1.ICoin[];
+  coins: proto.cosmos.base.v1beta1.ICoin[];
   privateKey: string;
 };
 
@@ -22,7 +22,7 @@ export class SendComponent implements OnInit {
   coins?: proto.cosmos.base.v1beta1.ICoin[] | null;
 
   @Input()
-  amounts?: proto.cosmos.base.v1beta1.ICoin[] | null;
+  sentCoins?: proto.cosmos.base.v1beta1.ICoin[] | null;
 
   @Output()
   appSubmit: EventEmitter<SendOnSubmitEvent>;
@@ -34,19 +34,19 @@ export class SendComponent implements OnInit {
   ngOnInit(): void {}
 
   onSubmit(toAddress: string, privateKey: string) {
-    if (!this.amounts) {
+    if (!this.sentCoins) {
       return;
     }
     this.appSubmit.emit({
       key: this.key!,
       toAddress,
-      amount: this.amounts
-        .filter((value) => {
-          return Number(value.amount) > 0;
+      coins: this.sentCoins
+        .filter((sentCoin) => {
+          return Number(sentCoin.amount) > 0;
         })
-        .map((value) => ({
-          denom: value.denom,
-          amount: value.amount?.toString(),
+        .map((sentCoin) => ({
+          denom: sentCoin.denom,
+          amount: sentCoin.amount?.toString(),
         })),
       privateKey,
     });

--- a/projects/main/src/app/views/cosmos/bank/send/send.component.ts
+++ b/projects/main/src/app/views/cosmos/bank/send/send.component.ts
@@ -5,7 +5,7 @@ import { proto } from '@cosmos-client/core';
 export type SendOnSubmitEvent = {
   key: Key;
   toAddress: string;
-  coins: proto.cosmos.base.v1beta1.ICoin[];
+  amount: proto.cosmos.base.v1beta1.ICoin[];
   privateKey: string;
 };
 
@@ -22,7 +22,7 @@ export class SendComponent implements OnInit {
   coins?: proto.cosmos.base.v1beta1.ICoin[] | null;
 
   @Input()
-  sentCoins?: proto.cosmos.base.v1beta1.ICoin[] | null;
+  amount?: proto.cosmos.base.v1beta1.ICoin[] | null;
 
   @Output()
   appSubmit: EventEmitter<SendOnSubmitEvent>;
@@ -34,19 +34,19 @@ export class SendComponent implements OnInit {
   ngOnInit(): void {}
 
   onSubmit(toAddress: string, privateKey: string) {
-    if (!this.sentCoins) {
+    if (!this.amount) {
       return;
     }
     this.appSubmit.emit({
       key: this.key!,
       toAddress,
-      coins: this.sentCoins
-        .filter((sentCoin) => {
-          return Number(sentCoin.amount) > 0;
+      amount: this.amount
+        .filter((coin) => {
+          return Number(coin.amount) > 0;
         })
-        .map((sentCoin) => ({
-          denom: sentCoin.denom,
-          amount: sentCoin.amount?.toString(),
+        .map((coin) => ({
+          denom: coin.denom,
+          amount: coin.amount?.toString(),
         })),
       privateKey,
     });

--- a/projects/main/src/app/views/cosmos/bank/send/send.component.ts
+++ b/projects/main/src/app/views/cosmos/bank/send/send.component.ts
@@ -22,7 +22,7 @@ export class SendComponent implements OnInit {
   coins?: proto.cosmos.base.v1beta1.ICoin[] | null;
 
   @Input()
-  amount?: proto.cosmos.base.v1beta1.ICoin[] | null;
+  amounts?: proto.cosmos.base.v1beta1.ICoin[] | null;
 
   @Output()
   appSubmit: EventEmitter<SendOnSubmitEvent>;
@@ -34,16 +34,20 @@ export class SendComponent implements OnInit {
   ngOnInit(): void {}
 
   onSubmit(toAddress: string, privateKey: string) {
-    if (!this.amount) {
+    if (!this.amounts) {
       return;
     }
     this.appSubmit.emit({
       key: this.key!,
       toAddress,
-      amount: this.amount.map((data) => ({
-        denom: data.denom,
-        amount: data.amount?.toString(),
-      })),
+      amount: this.amounts
+        .filter((value) => {
+          return Number(value.amount) > 0;
+        })
+        .map((value) => ({
+          denom: value.denom,
+          amount: value.amount?.toString(),
+        })),
       privateKey,
     });
   }

--- a/projects/main/src/app/views/cosmos/bank/send/send.component.ts
+++ b/projects/main/src/app/views/cosmos/bank/send/send.component.ts
@@ -2,6 +2,11 @@ import { Key } from '../../../../models/keys/key.model';
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { proto } from '@cosmos-client/core';
 
+interface Denom {
+  value: string;
+  viewValue: string;
+}
+
 export type SendOnSubmitEvent = {
   key: Key;
   toAddress: string;
@@ -54,4 +59,13 @@ export class SendComponent implements OnInit {
       privateKey,
     });
   }
+
+  tokens: Denom[] = [
+    { value: 'jpyx', viewValue: 'JPYX: JPY Stable Coin' },
+    { value: 'ujpyx', viewValue: 'uJPYX: 10^(-6) JPYX' },
+    { value: 'btc', viewValue: 'BTC: Bitcoin' },
+    { value: 'ubtc', viewValue: 'uBTC: 10^(-6) BTC' },
+    { value: 'jcbn', viewValue: 'JCBN: Governance Token for JPYX' },
+    { value: 'ujcbn', viewValue: 'uJCBN: 10^(-6) JCBN' },
+  ];
 }

--- a/projects/main/src/app/views/cosmos/bank/send/send.component.ts
+++ b/projects/main/src/app/views/cosmos/bank/send/send.component.ts
@@ -2,11 +2,6 @@ import { Key } from '../../../../models/keys/key.model';
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { proto } from '@cosmos-client/core';
 
-interface Denom {
-  value: string;
-  viewValue: string;
-}
-
 export type SendOnSubmitEvent = {
   key: Key;
   toAddress: string;
@@ -26,29 +21,22 @@ export class SendComponent implements OnInit {
   @Input()
   coins?: proto.cosmos.base.v1beta1.ICoin[] | null;
 
+  @Input()
+  amount?: proto.cosmos.base.v1beta1.ICoin[] | null;
+
   @Output()
   appSubmit: EventEmitter<SendOnSubmitEvent>;
 
-  amount: proto.cosmos.base.v1beta1.ICoin[];
-
   constructor() {
     this.appSubmit = new EventEmitter();
-    this.amount = [{ denom: '', amount: '' }];
   }
 
   ngOnInit(): void {}
 
-  removeAmount(index: number) {
-    this.amount.splice(index, 1);
-    return false;
-  }
-
-  addAmount() {
-    this.amount.push({});
-    return false;
-  }
-
   onSubmit(toAddress: string, privateKey: string) {
+    if (!this.amount) {
+      return;
+    }
     this.appSubmit.emit({
       key: this.key!,
       toAddress,
@@ -59,13 +47,4 @@ export class SendComponent implements OnInit {
       privateKey,
     });
   }
-
-  tokens: Denom[] = [
-    { value: 'jpyx', viewValue: 'JPYX: JPY Stable Coin' },
-    { value: 'ujpyx', viewValue: 'uJPYX: 10^(-6) JPYX' },
-    { value: 'btc', viewValue: 'BTC: Bitcoin' },
-    { value: 'ubtc', viewValue: 'uBTC: 10^(-6) BTC' },
-    { value: 'jcbn', viewValue: 'JCBN: Governance Token for JPYX' },
-    { value: 'ujcbn', viewValue: 'uJCBN: 10^(-6) JCBN' },
-  ];
 }


### PR DESCRIPTION
close #207 
#222 も一部解決

bank.application.serviceにて、返ってきたtx_response.codeによってエラーを吐く仕様に変更。
そのため。間違ったDenomなどの場合にtx_response.raw_logをSnackBarに表示しています。

> HTML上でプルダウンリストにする
denomの選択について本PRでは対応していませんが、もし必要であればコメントお願いします。
'invalid coin'のエラーは出るので不要な気もします。

@YasunoriMATSUOKA 確認お願いします。

![invalidcoin](https://user-images.githubusercontent.com/29295263/142808660-6ca7bbeb-5b6c-4553-87b3-69fe63ac1cf8.png)


