### PR TITLE
feat: delete angular flex layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@angular/common": "~12.2.0",
         "@angular/compiler": "~12.2.0",
         "@angular/core": "~12.2.0",
-        "@angular/flex-layout": "^12.0.0-beta.34",
         "@angular/forms": "~12.2.0",
         "@angular/material": "^12.2.4",
         "@angular/platform-browser": "~12.2.0",
@@ -695,6 +694,7 @@
       "version": "12.0.0-beta.34",
       "resolved": "https://registry.npmjs.org/@angular/flex-layout/-/flex-layout-12.0.0-beta.34.tgz",
       "integrity": "sha512-nLwKovXpyG+/U3Lbmfwt+q4ARupxtbPmFTZD0Y8oItFAV6/Oh9l+QQsNQa2VhOHAOrVagyDwcEM+SePtB5EmrQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -26453,6 +26453,7 @@
       "version": "12.0.0-beta.34",
       "resolved": "https://registry.npmjs.org/@angular/flex-layout/-/flex-layout-12.0.0-beta.34.tgz",
       "integrity": "sha512-nLwKovXpyG+/U3Lbmfwt+q4ARupxtbPmFTZD0Y8oItFAV6/Oh9l+QQsNQa2VhOHAOrVagyDwcEM+SePtB5EmrQ==",
+      "peer": true,
       "requires": {
         "tslib": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@angular/common": "~12.2.0",
     "@angular/compiler": "~12.2.0",
     "@angular/core": "~12.2.0",
-    "@angular/flex-layout": "^12.0.0-beta.34",
     "@angular/forms": "~12.2.0",
     "@angular/material": "^12.2.4",
     "@angular/platform-browser": "~12.2.0",

--- a/projects/main/src/app/views/accounts/account/account.module.ts
+++ b/projects/main/src/app/views/accounts/account/account.module.ts
@@ -2,12 +2,11 @@ import { MaterialModule } from '../../../views/material.module';
 import { AccountComponent } from './account.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [AccountComponent],
-  imports: [CommonModule, RouterModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, MaterialModule],
   exports: [AccountComponent],
 })
-export class AccountModule {}
+export class AccountModule { }

--- a/projects/main/src/app/views/accounts/account/bank/bank.module.ts
+++ b/projects/main/src/app/views/accounts/account/bank/bank.module.ts
@@ -2,12 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BankComponent } from './bank.component';
 import { RouterModule } from '@angular/router';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { MaterialModule } from '../../../material.module';
 
 @NgModule({
   declarations: [BankComponent],
-  imports: [CommonModule, RouterModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, MaterialModule],
   exports: [BankComponent],
 })
 export class BankModule { }

--- a/projects/main/src/app/views/accounts/account/distribution/distribution.module.ts
+++ b/projects/main/src/app/views/accounts/account/distribution/distribution.module.ts
@@ -2,12 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DistributionComponent as DistributionComponent } from './distribution.component';
 import { RouterModule } from '@angular/router';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { MaterialModule } from '../../../material.module';
 
 @NgModule({
   declarations: [DistributionComponent],
-  imports: [CommonModule, RouterModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, MaterialModule],
   exports: [DistributionComponent],
 })
 export class DistributionModule { }

--- a/projects/main/src/app/views/accounts/account/staking/staking.module.ts
+++ b/projects/main/src/app/views/accounts/account/staking/staking.module.ts
@@ -2,12 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { StakingComponent } from './staking.component';
 import { RouterModule } from '@angular/router';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { MaterialModule } from '../../../material.module';
 
 @NgModule({
   declarations: [StakingComponent],
-  imports: [CommonModule, RouterModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, MaterialModule],
   exports: [StakingComponent],
 })
 export class StakingModule { }

--- a/projects/main/src/app/views/blocks/block/block.module.ts
+++ b/projects/main/src/app/views/blocks/block/block.module.ts
@@ -3,11 +3,10 @@ import { CommonModule } from '@angular/common';
 import { BlockComponent } from './block.component';
 import { MaterialModule } from '../../material.module';
 import { RouterModule } from '@angular/router';
-import { FlexLayoutModule } from '@angular/flex-layout';
 
 @NgModule({
   declarations: [BlockComponent],
-  imports: [CommonModule, RouterModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, MaterialModule],
   exports: [BlockComponent],
 })
 export class BlockModule { }

--- a/projects/main/src/app/views/blocks/blocks.module.ts
+++ b/projects/main/src/app/views/blocks/blocks.module.ts
@@ -3,11 +3,10 @@ import { CommonModule } from '@angular/common';
 import { BlocksComponent } from './blocks.component';
 import { MaterialModule } from '../material.module';
 import { RouterModule } from '@angular/router';
-import { FlexLayoutModule } from '@angular/flex-layout';
 
 @NgModule({
   declarations: [BlocksComponent],
-  imports: [CommonModule, MaterialModule, RouterModule, FlexLayoutModule],
+  imports: [CommonModule, MaterialModule, RouterModule],
   exports: [BlocksComponent]
 })
 export class BlocksModule { }

--- a/projects/main/src/app/views/cosmos/bank/bank.module.ts
+++ b/projects/main/src/app/views/cosmos/bank/bank.module.ts
@@ -2,12 +2,11 @@ import { MaterialModule } from '../../../views/material.module';
 import { BankComponent } from './bank.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [BankComponent],
-  imports: [CommonModule, RouterModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, MaterialModule],
   exports: [BankComponent],
 })
-export class BankModule {}
+export class BankModule { }

--- a/projects/main/src/app/views/cosmos/bank/send/send.module.ts
+++ b/projects/main/src/app/views/cosmos/bank/send/send.module.ts
@@ -2,14 +2,13 @@ import { MaterialModule } from '../../../../views/material.module';
 import { SendComponent } from './send.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { MinModule } from 'ng-min-max';
 
 @NgModule({
   declarations: [SendComponent],
-  imports: [CommonModule, RouterModule, FormsModule, FlexLayoutModule, MaterialModule, MinModule],
+  imports: [CommonModule, RouterModule, FormsModule, MaterialModule, MinModule],
   exports: [SendComponent],
 })
-export class SendModule {}
+export class SendModule { }

--- a/projects/main/src/app/views/cosmos/gov/gov.module.ts
+++ b/projects/main/src/app/views/cosmos/gov/gov.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { GovComponent } from './gov.component';
 import { RouterModule } from '@angular/router';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { MaterialModule } from '../../material.module';
 
 @NgModule({
@@ -10,7 +9,7 @@ import { MaterialModule } from '../../material.module';
     GovComponent
   ],
   imports: [
-    CommonModule, RouterModule, FlexLayoutModule, MaterialModule
+    CommonModule, RouterModule, MaterialModule
   ],
   exports: [
     GovComponent

--- a/projects/main/src/app/views/cosmos/gov/proposals/proposal/proposal.module.ts
+++ b/projects/main/src/app/views/cosmos/gov/proposals/proposal/proposal.module.ts
@@ -2,12 +2,11 @@ import { MaterialModule } from '../../../../../views/material.module';
 import { ProposalComponent } from './proposal.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [ProposalComponent],
-  imports: [CommonModule, RouterModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, MaterialModule],
   exports: [ProposalComponent],
 })
-export class ProposalModule {}
+export class ProposalModule { }

--- a/projects/main/src/app/views/cosmos/gov/proposals/proposals.module.ts
+++ b/projects/main/src/app/views/cosmos/gov/proposals/proposals.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ProposalsComponent } from './proposals.component';
 import { RouterModule } from '@angular/router';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { MaterialModule } from '../../../material.module';
 
 
@@ -12,7 +11,7 @@ import { MaterialModule } from '../../../material.module';
     ProposalsComponent
   ],
   imports: [
-    CommonModule, RouterModule, FlexLayoutModule, MaterialModule
+    CommonModule, RouterModule, MaterialModule
   ],
   exports: [
     ProposalsComponent

--- a/projects/main/src/app/views/cosmos/staking/delegators/create/create.module.ts
+++ b/projects/main/src/app/views/cosmos/staking/delegators/create/create.module.ts
@@ -2,14 +2,13 @@ import { MaterialModule } from '../../../../../views/material.module';
 import { CreateComponent } from './create.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { MinModule } from 'ng-min-max';
 
 @NgModule({
   declarations: [CreateComponent],
-  imports: [CommonModule, RouterModule, FormsModule, FlexLayoutModule, MaterialModule, MinModule],
+  imports: [CommonModule, RouterModule, FormsModule, MaterialModule, MinModule],
   exports: [CreateComponent],
 })
-export class CreateModule {}
+export class CreateModule { }

--- a/projects/main/src/app/views/cosmos/staking/staking.module.ts
+++ b/projects/main/src/app/views/cosmos/staking/staking.module.ts
@@ -2,12 +2,11 @@ import { MaterialModule } from '../../../views/material.module';
 import { StakingComponent } from './staking.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [StakingComponent],
-  imports: [CommonModule, RouterModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, MaterialModule],
   exports: [StakingComponent],
 })
-export class StakingModule {}
+export class StakingModule { }

--- a/projects/main/src/app/views/cosmos/staking/validators/validator/validator.module.ts
+++ b/projects/main/src/app/views/cosmos/staking/validators/validator/validator.module.ts
@@ -2,12 +2,11 @@ import { MaterialModule } from '../../../../../views/material.module';
 import { ValidatorComponent } from './validator.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [ValidatorComponent],
-  imports: [CommonModule, RouterModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, MaterialModule],
   exports: [ValidatorComponent],
 })
-export class ValidatorModule {}
+export class ValidatorModule { }

--- a/projects/main/src/app/views/cosmos/staking/validators/validators.module.ts
+++ b/projects/main/src/app/views/cosmos/staking/validators/validators.module.ts
@@ -2,12 +2,11 @@ import { MaterialModule } from '../../../../views/material.module';
 import { ValidatorsComponent } from './validators.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [ValidatorsComponent],
-  imports: [CommonModule, RouterModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, MaterialModule],
   exports: [ValidatorsComponent],
 })
-export class ValidatorsModule {}
+export class ValidatorsModule { }

--- a/projects/main/src/app/views/faucet/faucet.module.ts
+++ b/projects/main/src/app/views/faucet/faucet.module.ts
@@ -1,7 +1,6 @@
 import { FaucetComponent } from './faucet.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { MaxModule, MinModule } from 'ng-min-max';
@@ -15,9 +14,8 @@ import { MaterialModule } from 'projects/main/src/app/views/material.module';
     FormsModule,
     MinModule,
     MaxModule,
-    FlexLayoutModule,
     MaterialModule,
   ],
   exports: [FaucetComponent],
 })
-export class FaucetModule {}
+export class FaucetModule { }

--- a/projects/main/src/app/views/home/bank/bank.module.ts
+++ b/projects/main/src/app/views/home/bank/bank.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BankComponent } from './bank.component';
 import { RouterModule } from '@angular/router';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { MaterialModule } from '../../material.module';
 
 @NgModule({
@@ -10,7 +9,7 @@ import { MaterialModule } from '../../material.module';
     BankComponent
   ],
   imports: [
-    CommonModule, RouterModule, FlexLayoutModule, MaterialModule
+    CommonModule, RouterModule, MaterialModule
   ],
   exports: [
     BankComponent

--- a/projects/main/src/app/views/home/blocks/blocks.module.ts
+++ b/projects/main/src/app/views/home/blocks/blocks.module.ts
@@ -2,12 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BlocksComponent } from './blocks.component';
 import { RouterModule } from '@angular/router';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { MaterialModule } from '../../material.module';
 
 @NgModule({
   declarations: [BlocksComponent],
-  imports: [CommonModule, RouterModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, MaterialModule],
   exports: [BlocksComponent],
 })
 export class BlocksModule { }

--- a/projects/main/src/app/views/home/distribution/distribution.module.ts
+++ b/projects/main/src/app/views/home/distribution/distribution.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DistributionComponent } from './distribution.component';
 import { RouterModule } from '@angular/router';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { MaterialModule } from '../../material.module';
 
 
@@ -12,7 +11,7 @@ import { MaterialModule } from '../../material.module';
     DistributionComponent
   ],
   imports: [
-    CommonModule, RouterModule, FlexLayoutModule, MaterialModule
+    CommonModule, RouterModule, MaterialModule
   ],
   exports: [
     DistributionComponent

--- a/projects/main/src/app/views/home/home.module.ts
+++ b/projects/main/src/app/views/home/home.module.ts
@@ -2,13 +2,12 @@ import { MaterialModule } from '../../views/material.module';
 import { HomeComponent } from './home.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [HomeComponent],
-  imports: [CommonModule, RouterModule, FormsModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, FormsModule, MaterialModule],
   exports: [HomeComponent],
 })
-export class HomeModule {}
+export class HomeModule { }

--- a/projects/main/src/app/views/home/mint/mint.module.ts
+++ b/projects/main/src/app/views/home/mint/mint.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MintComponent } from './mint.component';
 import { RouterModule } from '@angular/router';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { MaterialModule } from '../../material.module';
 
 @NgModule({
@@ -10,7 +9,7 @@ import { MaterialModule } from '../../material.module';
     MintComponent
   ],
   imports: [
-    CommonModule, RouterModule, FlexLayoutModule, MaterialModule
+    CommonModule, RouterModule, MaterialModule
   ],
   exports: [
     MintComponent

--- a/projects/main/src/app/views/home/txs/txs.module.ts
+++ b/projects/main/src/app/views/home/txs/txs.module.ts
@@ -1,13 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TxsComponent } from './txs.component';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { MaterialModule } from '../../material.module';
 import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [TxsComponent],
-  imports: [CommonModule, RouterModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, MaterialModule],
   exports: [TxsComponent],
 })
 export class TxsModule { }

--- a/projects/main/src/app/views/keys/create/create.module.ts
+++ b/projects/main/src/app/views/keys/create/create.module.ts
@@ -3,7 +3,6 @@ import { CreateComponent } from './create.component';
 import { ClipboardModule } from '@angular/cdk/clipboard';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 
@@ -13,10 +12,9 @@ import { RouterModule } from '@angular/router';
     CommonModule,
     RouterModule,
     FormsModule,
-    FlexLayoutModule,
     MaterialModule,
     ClipboardModule,
   ],
   exports: [CreateComponent],
 })
-export class CreateModule {}
+export class CreateModule { }

--- a/projects/main/src/app/views/keys/key-select-dialog/key-select-dialog.module.ts
+++ b/projects/main/src/app/views/keys/key-select-dialog/key-select-dialog.module.ts
@@ -2,12 +2,11 @@ import { MaterialModule } from '../../../views/material.module';
 import { KeySelectDialogComponent } from './key-select-dialog.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [KeySelectDialogComponent],
-  imports: [CommonModule, RouterModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, MaterialModule],
   exports: [KeySelectDialogComponent],
 })
-export class KeySelectDialogModule {}
+export class KeySelectDialogModule { }

--- a/projects/main/src/app/views/keys/key/key.module.ts
+++ b/projects/main/src/app/views/keys/key/key.module.ts
@@ -2,12 +2,11 @@ import { MaterialModule } from '../../../views/material.module';
 import { KeyComponent } from './key.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [KeyComponent],
-  imports: [CommonModule, RouterModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, MaterialModule],
   exports: [KeyComponent],
 })
-export class KeyModule {}
+export class KeyModule { }

--- a/projects/main/src/app/views/keys/keys.module.ts
+++ b/projects/main/src/app/views/keys/keys.module.ts
@@ -2,12 +2,11 @@ import { MaterialModule } from '../../views/material.module';
 import { KeysComponent } from './keys.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [KeysComponent],
-  imports: [CommonModule, RouterModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, MaterialModule],
   exports: [KeysComponent],
 })
-export class KeysModule {}
+export class KeysModule { }

--- a/projects/main/src/app/views/keys/sign/sign.module.ts
+++ b/projects/main/src/app/views/keys/sign/sign.module.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { SignComponent } from './sign.component';
 import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { MaterialModule } from '../../material.module';
 
 @NgModule({
@@ -14,7 +13,6 @@ import { MaterialModule } from '../../material.module';
     CommonModule,
     RouterModule,
     FormsModule,
-    FlexLayoutModule,
     MaterialModule
   ],
   exports: [SignComponent]

--- a/projects/main/src/app/views/monitor/monitor.component.html
+++ b/projects/main/src/app/views/monitor/monitor.component.html
@@ -1,7 +1,7 @@
 <h2>Daily Rewards</h2>
 <mat-card>
   <form #formRef="ngForm" (submit)="onSubmit(startRef.value, endRef.value)">
-    <mat-form-field fxFill>
+    <mat-form-field class="w-full">
       <mat-label>Choose a Date Range</mat-label>
       <mat-date-range-input [rangePicker]="picker">
         <input #startRef="ngModel" name="startDate" [ngModel]="startDate" matStartDate matInput placeholder="Start date"
@@ -13,7 +13,7 @@
       <mat-date-range-picker #picker></mat-date-range-picker>
     </mat-form-field>
     <br />
-    <button mat-flat-button fxFill color="accent" [disabled]="formRef.invalid">Submit</button>
+    <button mat-flat-button class="w-full" color="accent" [disabled]="formRef.invalid">Submit</button>
   </form>
 </mat-card>
 <br />

--- a/projects/main/src/app/views/monitor/monitor.module.ts
+++ b/projects/main/src/app/views/monitor/monitor.module.ts
@@ -2,7 +2,6 @@ import { MaterialModule } from '../material.module';
 import { MonitorComponent } from './monitor.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
@@ -14,11 +13,10 @@ import { RouterModule } from '@angular/router';
     CommonModule,
     RouterModule,
     FormsModule,
-    FlexLayoutModule,
     MaterialModule,
     MatDatepickerModule,
     MatNativeDateModule,
   ],
   exports: [MonitorComponent],
 })
-export class MonitorModule {}
+export class MonitorModule { }

--- a/projects/main/src/app/views/toolbar/toolbar.component.css
+++ b/projects/main/src/app/views/toolbar/toolbar.component.css
@@ -1,8 +1,0 @@
-form {
-  font-size: initial;
-  margin-top: 1.34375em;
-}
-
-form.xs {
-  margin-top: 1em;
-}

--- a/projects/main/src/app/views/toolbar/toolbar.component.html
+++ b/projects/main/src/app/views/toolbar/toolbar.component.html
@@ -1,4 +1,4 @@
-<form #form="ngForm" class="text-base mt-4 xs:text-xxl">
+<form #form="ngForm" class="text-base mt-4 xs:mt-5">
   <mat-form-field appearance="fill" (submit)="onSubmit(searchValueRef.value)">
     <mat-label>Search</mat-label>
     <input #searchValueRef matInput required id="searchValue" name="searchValue" [ngModel]="searchValue"

--- a/projects/main/src/app/views/toolbar/toolbar.component.html
+++ b/projects/main/src/app/views/toolbar/toolbar.component.html
@@ -1,4 +1,4 @@
-<form #form="ngForm" class="text-base mt-4 xs:mt-5">
+<form #form="ngForm" class="text-base mt-4 sm:mt-6">
   <mat-form-field appearance="fill" (submit)="onSubmit(searchValueRef.value)">
     <mat-label>Search</mat-label>
     <input #searchValueRef matInput required id="searchValue" name="searchValue" [ngModel]="searchValue"

--- a/projects/main/src/app/views/toolbar/toolbar.component.html
+++ b/projects/main/src/app/views/toolbar/toolbar.component.html
@@ -1,28 +1,14 @@
 <form #form="ngForm" [ngClass.xs]="'xs'">
   <mat-form-field appearance="fill" (submit)="onSubmit(searchValueRef.value)">
     <mat-label>Search</mat-label>
-    <input
-      #searchValueRef
-      matInput
-      required
-      id="searchValue"
-      name="searchValue"
-      [ngModel]="searchValue"
-      [matAutocomplete]="auto"
-    />
-    <mat-autocomplete
-      #auto="matAutocomplete"
-      (optionSelected)="onOptionSelected($event.option.value)"
-    >
+    <input #searchValueRef matInput required id="searchValue" name="searchValue" [ngModel]="searchValue"
+      [matAutocomplete]="auto" />
+    <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onOptionSelected($event.option.value)">
       <mat-option *ngFor="let option of options" [value]="option.format(searchValueRef.value)">
         {{ option.label(searchValueRef.value) }}
       </mat-option>
     </mat-autocomplete>
-    <button
-      mat-icon-button
-      matSuffix
-      [disabled]="form.invalid"
-    >
+    <button mat-icon-button matSuffix [disabled]="form.invalid">
       <mat-icon>search</mat-icon>
     </button>
   </mat-form-field>

--- a/projects/main/src/app/views/toolbar/toolbar.component.html
+++ b/projects/main/src/app/views/toolbar/toolbar.component.html
@@ -1,4 +1,4 @@
-<form #form="ngForm" [ngClass.xs]="'xs'">
+<form #form="ngForm" class="text-base mt-4 xs:text-xxl">
   <mat-form-field appearance="fill" (submit)="onSubmit(searchValueRef.value)">
     <mat-label>Search</mat-label>
     <input #searchValueRef matInput required id="searchValue" name="searchValue" [ngModel]="searchValue"

--- a/projects/main/src/app/views/toolbar/toolbar.module.ts
+++ b/projects/main/src/app/views/toolbar/toolbar.module.ts
@@ -2,13 +2,12 @@ import { MaterialModule } from '../../views/material.module';
 import { ToolbarComponent } from './toolbar.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 
 @NgModule({
   declarations: [ToolbarComponent],
-  imports: [CommonModule, RouterModule, FormsModule, FlexLayoutModule, MaterialModule],
+  imports: [CommonModule, RouterModule, FormsModule, MaterialModule],
   exports: [ToolbarComponent],
 })
-export class ToolbarModule {}
+export class ToolbarModule { }

--- a/projects/main/src/app/views/txs/txs.module.ts
+++ b/projects/main/src/app/views/txs/txs.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TxsComponent } from './txs.component';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { MaterialModule } from '../material.module';
 import { RouterModule } from '@angular/router';
 
@@ -12,7 +11,6 @@ import { RouterModule } from '@angular/router';
   imports: [
     CommonModule,
     RouterModule,
-    FlexLayoutModule,
     MaterialModule
   ],
   exports: [

--- a/projects/main/src/app/views/view.module.ts
+++ b/projects/main/src/app/views/view.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { FlexLayoutModule } from '@angular/flex-layout';
 import { MaterialModule } from './material.module';
 import { AppComponent } from './app.component';
 import { RouterModule } from '@angular/router';
@@ -13,7 +12,6 @@ import { ToolbarModule } from './toolbar/toolbar.module';
     CommonModule,
     RouterModule,
     FormsModule,
-    FlexLayoutModule,
     MaterialModule,
     ToolbarModule
   ],


### PR DESCRIPTION
[#94](https://github.com/lcnem/telescope/issues/94)
以下の手順でflex-layout削除しました。
１、package.jsonからflex-layout削除
２、node_modulesフォルダを削除
３，npm i 

[package-lock.jsonはnpmインストールした際の具体的なバージョンを保存するもので、人が編集するものではないとの記事
[https://qiita.com/sugurutakahashi12345/items/1f6bb7a372b8263500e5](https://qiita.com/sugurutakahashi12345/items/1f6bb7a372b8263500e5)

を見たので今回触っていませんが、package-lock.jsonの中にflex-layoutの文字が残っているのが気になりました。問題ないかご確認お願いしたいです。

表示について、ローカルとデブロイされているサイトを並べて確認し問題ないと思いました。
差異があったのは以下３点です。
①Transaction
![20211123_flexlayout1](https://user-images.githubusercontent.com/75844498/143009994-21712ddc-1d95-4260-bc56-b2873d62207e.png)
こちらはローカル側は問題ないと思いますが、デブロイされている方がメッセージタイプ”o”となっており別で調査が必要かと思います。

②Monitor
![20211123_flexlayout2](https://user-images.githubusercontent.com/75844498/143010027-19d25432-5ade-439a-b7cf-01270bfaa86f.png)
③JPYX
![20211123_flexlayout3](https://user-images.githubusercontent.com/75844498/143010039-59cd7c9a-828d-41be-b481-152f1fcb7122.png)
2、3はbotanyの範囲なのでこちらも同様にflex-layoutの削除が必要と考えます。
（telescopeのflex-layout削除手順の確認いただいたのち実施します。）

