### PR TITLE
feat: delete last element divider

### DIFF
--- a/projects/main/src/app/views/blocks/block/block.component.html
+++ b/projects/main/src/app/views/blocks/block/block.component.html
@@ -22,13 +22,12 @@
         {{ block?.block?.header?.time | date : 'yyyy-M-d a h:mm:ss z' }}
       </span>
     </mat-list-item>
-    <mat-divider [inset]="true"></mat-divider>
   </mat-list>
 </mat-card>
 
-<h3>Validatorsets</h3>
+<h3>Validator sets</h3>
 <ng-container *ngFor="let validatorset of validatorsets?.validators">
-  <mat-card>
+  <mat-card class="mb-2">
     <mat-list>
       <mat-list-item>
         <span class="whitespace-nowrap">Address:</span>
@@ -47,7 +46,6 @@
         <span class="flex-auto"></span>
         <span class="ml-2 break-all text-sm sm:text-base">{{ validatorset.proposer_priority }}</span>
       </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
     </mat-list>
   </mat-card>
 </ng-container>

--- a/projects/main/src/app/views/home/bank/bank.component.html
+++ b/projects/main/src/app/views/home/bank/bank.component.html
@@ -1,11 +1,11 @@
 <h2>Total Supply</h2>
 <mat-card>
-  <mat-list *ngFor="let sup of totalSupply?.supply">
+  <mat-list *ngFor="let sup of totalSupply?.supply; last as last">
     <mat-list-item>
       <span>{{ sup.amount | number:'1.0-0' }}</span>
       <span class="flex-auto"></span>
       <span>{{ sup.denom }}</span>
-      <mat-divider></mat-divider>
+      <mat-divider *ngIf="!last"></mat-divider>
     </mat-list-item>
   </mat-list>
 </mat-card>

--- a/projects/main/src/app/views/home/blocks/blocks.component.html
+++ b/projects/main/src/app/views/home/blocks/blocks.component.html
@@ -20,7 +20,7 @@
           <span class="flex-auto"></span>
           <span class="break-all truncate">Time</span>
         </mat-list-item>
-        <ng-container *ngFor="let latestBlock of latestBlocks">
+        <ng-container *ngFor="let latestBlock of latestBlocks; last as last">
           <mat-divider></mat-divider>
           <mat-list-item routerLink="/blocks/{{ latestBlock?.block?.header?.height }}">
             <span class="pr-4">{{ latestBlock?.block?.header?.height }}</span>
@@ -29,7 +29,7 @@
               {{ latestBlock?.block?.header?.time | date : 'yyyy-M-d a h:mm:ss z' }}
             </span>
           </mat-list-item>
-          <mat-divider></mat-divider>
+          <mat-divider *ngIf="!last"></mat-divider>
         </ng-container>
       </ng-template>
     </mat-nav-list>

--- a/projects/main/src/app/views/home/distribution/distribution.component.html
+++ b/projects/main/src/app/views/home/distribution/distribution.component.html
@@ -1,11 +1,11 @@
 <h2>Community Pool</h2>
 <mat-card>
-  <mat-list *ngFor="let pool of communityPool?.pool">
+  <mat-list *ngFor="let pool of communityPool?.pool; last as last">
     <mat-list-item>
       <span>{{ pool.amount | number:'1.6-6' }}</span>
       <span class="flex-auto"></span>
       <span>{{ pool.denom }}</span>
-      <mat-divider></mat-divider>
+      <mat-divider *ngIf="!last"></mat-divider>
     </mat-list-item>
   </mat-list>
 </mat-card>

--- a/projects/main/src/app/views/home/home.component.html
+++ b/projects/main/src/app/views/home/home.component.html
@@ -35,7 +35,6 @@
         <span class="flex-auto"></span>
         <span class="ml-2 break-all">{{ nodeInfo?.default_node_info?.channels }}</span>
       </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
     </mat-list>
   </mat-card-content>
 </mat-card>
@@ -76,7 +75,6 @@
           {{ nodeInfo?.application_version?.go_version }}
         </span>
       </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
     </mat-list>
   </mat-card-content>
 </mat-card>
@@ -90,7 +88,6 @@
         <span class="flex-auto"></span>
         <span class="ml-2 break-all">{{ syncing }}</span>
       </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
     </mat-list>
   </mat-card-content>
 </mat-card>

--- a/projects/main/src/app/views/home/txs/txs.component.html
+++ b/projects/main/src/app/views/home/txs/txs.component.html
@@ -10,7 +10,7 @@
 <div class="overflow-scroll h-80">
   <mat-card>
     <mat-nav-list>
-      <ng-container *ngIf="txs === undefined || null ; then empty; else exist"></ng-container>
+      <ng-container *ngIf="txs === undefined || null; then empty; else exist"></ng-container>
       <ng-template #empty></ng-template>
       <ng-template #exist>
         <mat-list-item>
@@ -19,13 +19,13 @@
           <span class="break-all truncate">Tx Hash</span>
         </mat-list-item>
         <mat-divider></mat-divider>
-        <ng-container *ngFor="let tx of txs">
+        <ng-container *ngFor="let tx of txs; last as last">
           <mat-list-item routerLink="/txs/{{ tx.txhash }}">
             <span class="pr-4">{{ tx.height }}</span>
             <span class="flex-auto"></span>
             <span class="break-all truncate">{{ tx.txhash }}</span>
           </mat-list-item>
-          <mat-divider></mat-divider>
+          <mat-divider *ngIf="!last"></mat-divider>
         </ng-container>
       </ng-template>
     </mat-nav-list>

--- a/projects/main/src/app/views/home/txs/txs.component.html
+++ b/projects/main/src/app/views/home/txs/txs.component.html
@@ -19,13 +19,13 @@
           <span class="break-all truncate">Tx Hash</span>
         </mat-list-item>
         <mat-divider></mat-divider>
-        <ng-container *ngFor="let tx of txs; last as last">
+        <ng-container *ngFor="let tx of txs">
           <mat-list-item routerLink="/txs/{{ tx.txhash }}">
             <span class="pr-4">{{ tx.height }}</span>
             <span class="flex-auto"></span>
             <span class="break-all truncate">{{ tx.txhash }}</span>
           </mat-list-item>
-          <mat-divider *ngIf="!last"></mat-divider>
+          <mat-divider></mat-divider>
         </ng-container>
       </ng-template>
     </mat-nav-list>

--- a/projects/main/src/app/views/home/txs/txs.component.html
+++ b/projects/main/src/app/views/home/txs/txs.component.html
@@ -19,13 +19,13 @@
           <span class="break-all truncate">Tx Hash</span>
         </mat-list-item>
         <mat-divider></mat-divider>
-        <ng-container *ngFor="let tx of txs">
+        <ng-container *ngFor="let tx of txs; last as last">
           <mat-list-item routerLink="/txs/{{ tx.txhash }}">
             <span class="pr-4 font-mono">{{ tx.height }}</span>
             <span class="flex-auto"></span>
             <span class="break-all truncate font-mono">{{ tx.txhash }}</span>
           </mat-list-item>
-          <mat-divider></mat-divider>
+          <mat-divider *ngIf="!last"></mat-divider>
         </ng-container>
       </ng-template>
     </mat-nav-list>

--- a/projects/main/src/app/views/txs/tx/tx.component.html
+++ b/projects/main/src/app/views/txs/tx/tx.component.html
@@ -36,7 +36,7 @@
         {{ tx?.tx_response?.timestamp | date : 'yyyy-M-d a h:mm:ss z' }}
       </span>
     </mat-list-item>
-    <mat-divider [inset]="true"></mat-divider>
+
   </mat-list>
 </mat-card>
 
@@ -51,13 +51,13 @@
           <span class="ml-2 break-all">{{ constructorName(msg) }}</span>
         </mat-list-item>
         <mat-divider [inset]="true"></mat-divider>
-        <ng-template ngFor let-data [ngForOf]="entries(msg)">
+        <ng-template ngFor let-data [ngForOf]="entries(msg)" let-last="last">
           <mat-list-item>
             <span class="whitespace-nowrap">{{ data[0] }}</span>
             <span class="flex-auto"></span>
             <span class="ml-2 break-all text-xs sm:text-base">{{ data[1] | json }}</span>
           </mat-list-item>
-          <mat-divider [inset]="true"></mat-divider>
+          <mat-divider [inset]="true" *ngIf="!last"></mat-divider>
         </ng-template>
       </mat-list>
     </mat-card>
@@ -67,7 +67,7 @@
 <h3>Signatures</h3>
 <ng-template ngFor let-signerInfo [ngForOf]="tx?.tx?.auth_info?.signer_infos">
   <ng-container *ngIf="unpackKey(signerInfo.public_key) as pubKey">
-    <mat-card>
+    <mat-card class="mb-2">
       <mat-list>
         <mat-list-item>
           <span class="whitespace-nowrap">Key Type: </span>
@@ -86,7 +86,6 @@
           <span class="flex-auto"></span>
           <span class="ml-2 break-all">{{ signerInfo?.mode_info }}</span>
         </mat-list-item>
-        <mat-divider [inset]="true"></mat-divider>
       </mat-list>
     </mat-card>
   </ng-container>
@@ -95,7 +94,7 @@
 <h3>Logs</h3>
 <ng-template ngFor let-log [ngForOf]="tx?.tx_response?.logs">
   <ng-template ngFor let-event [ngForOf]="log.events">
-    <mat-card>
+    <mat-card class="mb-2">
       <mat-list>
         <mat-list-item>
           <span class="whitespace-nowrap">Type: </span>
@@ -103,13 +102,13 @@
           <span class="ml-2 break-all">{{ event.type }}</span>
         </mat-list-item>
         <mat-divider [inset]="true"></mat-divider>
-        <ng-template ngFor let-attr [ngForOf]="event.attributes">
+        <ng-template ngFor let-attr [ngForOf]="event.attributes" let-last="last">
           <mat-list-item>
             <span class="whitespace-nowrap">{{ attr.key }}</span>
             <span class="flex-auto"></span>
             <span class="ml-2 break-all text-sm sm:text-base">{{ attr.value | json }}</span>
           </mat-list-item>
-          <mat-divider [inset]="true"></mat-divider>
+          <mat-divider [inset]="true" *ngIf="!last"></mat-divider>
         </ng-template>
       </mat-list>
     </mat-card>


### PR DESCRIPTION
[https://github.com/lcnem/telescope/issues/215](https://github.com/lcnem/telescope/issues/215)の修正です。

以下の記事を参考に実装しました。
[https://dev.classmethod.jp/articles/mat-divider-last-hidden/](https://dev.classmethod.jp/articles/mat-divider-last-hidden/)

レイアウト見てhome、Transaction詳細、Block詳細ページ以外のページはdividerが必要だと感じたので、
home、Transaction詳細、Block詳細ページのみ修正を行いました。
同様にhomeページ、Transactionのカードは、pagenationとの区別にdividerが必要だと思ったので
こちらも削除していません。

実装結果です。
![20211123_del_last_divider1](https://user-images.githubusercontent.com/75844498/143021597-53f49347-2a88-4205-8689-7f8c700332f9.png)

また、カードが連続している部分のレイアウトを見直しました。
![20211123_del_last_divider2](https://user-images.githubusercontent.com/75844498/143021593-20aa3302-3657-46c7-bb2f-d4fb09a0046e.png)

ご確認お願い致します。