### PR TITLE
feat: add simulation request to tx bank send

### DIFF
--- a/projects/main/config.js.template
+++ b/projects/main/config.js.template
@@ -10,6 +10,10 @@ const config = {
   //   consAddr: '',
   //   consPub: '',
   // },
+  // minimumGasPrices: {
+  //   denom: '';
+  //   amount: '';
+  // }[];
   // extension: {
   //   faucet: [
   //     {

--- a/projects/main/src/app/app.module.ts
+++ b/projects/main/src/app/app.module.ts
@@ -2,6 +2,7 @@ import { environment } from '../environments/environment';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { reducers, metaReducers } from './reducers';
+import { TxFeeConfirmDialogModule } from './views/cosmos/tx-fee-confirm-dialog/tx-fee-confirm-dialog.module';
 import { KeyBackupDialogModule } from './views/keys/key-backup-dialog/key-backup-dialog.module';
 import { KeyDeleteConfirmDialogModule } from './views/keys/key-delete-confirm-dialog/key-delete-confirm-dialog.module';
 import { KeyDeleteDialogModule } from './views/keys/key-delete-dialog/key-delete-dialog.module';
@@ -38,6 +39,7 @@ import { LoadingDialogModule } from 'ng-loading-dialog';
     KeyBackupDialogModule,
     KeyDeleteDialogModule,
     KeyDeleteConfirmDialogModule,
+    TxFeeConfirmDialogModule,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/projects/main/src/app/models/config.service.ts
+++ b/projects/main/src/app/models/config.service.ts
@@ -12,6 +12,10 @@ export type Config = {
     consAddr: string;
     consPub: string;
   };
+  minimumGasPrices: {
+    denom: string;
+    amount: string;
+  }[];
   extension?: {
     faucet?: {
       hasFaucet: boolean;

--- a/projects/main/src/app/models/cosmos/bank.application.service.ts
+++ b/projects/main/src/app/models/cosmos/bank.application.service.ts
@@ -21,13 +21,14 @@ export class BankApplicationService {
     key: Key,
     toAddress: string,
     amount: proto.cosmos.base.v1beta1.ICoin[],
+    minimumGasPrice: proto.cosmos.base.v1beta1.ICoin,
     privateKey: string,
   ) {
     const dialogRef = this.loadingDialog.open('Sending');
     let txhash: string | undefined;
 
     try {
-      const res = await this.bank.send(key, toAddress, amount, privateKey);
+      const res = await this.bank.send(key, toAddress, amount, minimumGasPrice, privateKey);
       txhash = res.tx_response?.txhash;
       if (txhash === undefined) {
         throw Error('Invalid txhash!');

--- a/projects/main/src/app/models/cosmos/bank.application.service.ts
+++ b/projects/main/src/app/models/cosmos/bank.application.service.ts
@@ -1,7 +1,7 @@
 import { TxFeeConfirmDialogComponent } from '../../views/cosmos/tx-fee-confirm-dialog/tx-fee-confirm-dialog.component';
 import { Key } from '../keys/key.model';
-import { SimulatedTxBankSendResultResponse } from './bank.model';
 import { BankService } from './bank.service';
+import { SimulatedTxResultResponse } from './tx-common.model';
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -29,7 +29,7 @@ export class BankApplicationService {
     privateKey: string,
   ) {
     // simulate
-    let simulatedResultData: SimulatedTxBankSendResultResponse;
+    let simulatedResultData: SimulatedTxResultResponse;
     let gas: proto.cosmos.base.v1beta1.ICoin;
     let fee: proto.cosmos.base.v1beta1.ICoin;
 

--- a/projects/main/src/app/models/cosmos/bank.application.service.ts
+++ b/projects/main/src/app/models/cosmos/bank.application.service.ts
@@ -1,6 +1,9 @@
+import { TxFeeConfirmDialogComponent } from '../../views/cosmos/tx-fee-confirm-dialog/tx-fee-confirm-dialog.component';
 import { Key } from '../keys/key.model';
+import { SimulatedTxBankSendResultResponse } from './bank.model';
 import { BankService } from './bank.service';
 import { Injectable } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { proto } from '@cosmos-client/core';
@@ -13,6 +16,7 @@ export class BankApplicationService {
   constructor(
     private readonly router: Router,
     private readonly snackBar: MatSnackBar,
+    private readonly dialog: MatDialog,
     private readonly loadingDialog: LoadingDialogService,
     private readonly bank: BankService,
   ) {}
@@ -24,18 +28,56 @@ export class BankApplicationService {
     minimumGasPrice: proto.cosmos.base.v1beta1.ICoin,
     privateKey: string,
   ) {
+    // simulate
+    let simulatedResultData: SimulatedTxBankSendResultResponse;
+    let gas: proto.cosmos.base.v1beta1.ICoin;
+    let fee: proto.cosmos.base.v1beta1.ICoin;
+
+    try {
+      simulatedResultData = await this.bank.simulateToSend(
+        key,
+        toAddress,
+        amount,
+        minimumGasPrice,
+        privateKey,
+      );
+      gas = simulatedResultData.estimatedGasUsedWithMargin;
+      fee = simulatedResultData.estimatedFeeWithMargin;
+    } catch (error) {
+      const errorMessage = `Tx simulation failed: ${(error as Error).toString()}`;
+      this.snackBar.open(`An error has occur: ${errorMessage}`);
+      return;
+    }
+
+    // ask the user to confirm the fee with a dialog
+    const txFeeConfirmedResult = await this.dialog
+      .open(TxFeeConfirmDialogComponent, {
+        data: {
+          fee,
+          isConfirmed: false,
+        },
+      })
+      .afterClosed()
+      .toPromise();
+
+    if (txFeeConfirmedResult === undefined || txFeeConfirmedResult.isConfirmed === false) {
+      this.snackBar.open('Tx was canceled', undefined, { duration: 6000 });
+      return;
+    }
+
+    // send tx
     const dialogRef = this.loadingDialog.open('Sending');
     let txhash: string | undefined;
 
     try {
-      const res = await this.bank.send(key, toAddress, amount, minimumGasPrice, privateKey);
+      const res = await this.bank.send(key, toAddress, amount, gas, fee, privateKey);
       txhash = res.tx_response?.txhash;
       if (txhash === undefined) {
         throw Error('Invalid txhash!');
       }
     } catch (error) {
       const msg = (error as Error).toString();
-      this.snackBar.open(`Error has occured: ${msg}`, undefined, {
+      this.snackBar.open(`An error has occur: ${msg}`, undefined, {
         duration: 6000,
       });
       return;

--- a/projects/main/src/app/models/cosmos/bank.model.ts
+++ b/projects/main/src/app/models/cosmos/bank.model.ts
@@ -1,0 +1,9 @@
+import { proto } from '@cosmos-client/core';
+import { InlineResponse20074 } from '@cosmos-client/core/esm/openapi';
+
+export type SimulatedTxBankSendResultResponse = {
+  simulatedResultData: InlineResponse20074;
+  minimumGasPrice: proto.cosmos.base.v1beta1.ICoin;
+  estimatedGasUsedWithMargin: proto.cosmos.base.v1beta1.ICoin;
+  estimatedFeeWithMargin: proto.cosmos.base.v1beta1.ICoin;
+};

--- a/projects/main/src/app/models/cosmos/bank.service.ts
+++ b/projects/main/src/app/models/cosmos/bank.service.ts
@@ -99,8 +99,7 @@ export class BankService {
       ? parseInt(simulatedGasUsed) * 1.1
       : 200000;
     const simulatedGasUsedWithMargin = simulatedGasUsedWithMarginNumber.toFixed(0);
-    // Todo: 0.015 depends on Node's config(`~/.jpyx/config/app.toml` minimum-gas-prices).
-    // Hardcode is not good.
+    // minimumGasPrice depends on Node's config(`~/.jpyx/config/app.toml` minimum-gas-prices).
     const simulatedFeeWithMarginNumber =
       parseInt(simulatedGasUsedWithMargin) *
       parseFloat(minimumGasPrice.amount ? minimumGasPrice.amount : '0');

--- a/projects/main/src/app/models/cosmos/bank.service.ts
+++ b/projects/main/src/app/models/cosmos/bank.service.ts
@@ -15,6 +15,7 @@ export class BankService {
     key: Key,
     toAddress: string,
     amount: proto.cosmos.base.v1beta1.ICoin[],
+    minimumGasPrice: proto.cosmos.base.v1beta1.ICoin,
     privateKey: string,
   ): Promise<InlineResponse20075> {
     const sdk = await this.cosmosSDK.sdk().then((sdk) => sdk.rest);
@@ -63,7 +64,7 @@ export class BankService {
       fee: {
         amount: [
           {
-            denom: 'ujcbn',
+            denom: minimumGasPrice.denom,
             amount: dummyFee,
           },
         ],
@@ -100,7 +101,9 @@ export class BankService {
     const simulatedGasUsedWithMargin = simulatedGasUsedWithMarginNumber.toFixed(0);
     // Todo: 0.015 depends on Node's config(`~/.jpyx/config/app.toml` minimum-gas-prices).
     // Hardcode is not good.
-    const simulatedFeeWithMarginNumber = parseInt(simulatedGasUsedWithMargin) * 0.015;
+    const simulatedFeeWithMarginNumber =
+      parseInt(simulatedGasUsedWithMargin) *
+      parseFloat(minimumGasPrice.amount ? minimumGasPrice.amount : '0');
     const simulatedFeeWithMargin = Math.ceil(simulatedFeeWithMarginNumber).toFixed(0);
     console.log({
       simulatedGasUsed,
@@ -125,7 +128,7 @@ export class BankService {
       fee: {
         amount: [
           {
-            denom: 'ujcbn',
+            denom: minimumGasPrice.denom,
             amount: simulatedFeeWithMargin,
           },
         ],

--- a/projects/main/src/app/models/cosmos/tx-common.model.ts
+++ b/projects/main/src/app/models/cosmos/tx-common.model.ts
@@ -1,0 +1,9 @@
+import { proto } from '@cosmos-client/core';
+import { InlineResponse20074 } from '@cosmos-client/core/esm/openapi';
+
+export type SimulatedTxResultResponse = {
+  simulatedResultData: InlineResponse20074;
+  minimumGasPrice: proto.cosmos.base.v1beta1.ICoin;
+  estimatedGasUsedWithMargin: proto.cosmos.base.v1beta1.ICoin;
+  estimatedFeeWithMargin: proto.cosmos.base.v1beta1.ICoin;
+};

--- a/projects/main/src/app/models/cosmos/tx-common.service.ts
+++ b/projects/main/src/app/models/cosmos/tx-common.service.ts
@@ -1,0 +1,81 @@
+import { CosmosSDKService } from '../cosmos-sdk.service';
+import { SimulatedTxResultResponse } from './tx-common.model';
+import { Injectable } from '@angular/core';
+import { cosmosclient, proto, rest } from '@cosmos-client/core';
+import { InlineResponse20075 } from '@cosmos-client/core/esm/openapi';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TxCommonService {
+  constructor(private readonly cosmosSDK: CosmosSDKService) {}
+
+  async simulateTx(
+    txBuilder: cosmosclient.TxBuilder,
+    minimumGasPrice: proto.cosmos.base.v1beta1.ICoin,
+  ): Promise<SimulatedTxResultResponse> {
+    const sdk = await this.cosmosSDK.sdk().then((sdk) => sdk.rest);
+
+    // restore json from txBuilder
+    const txForSimulation = JSON.parse(txBuilder.cosmosJSONStringify());
+
+    // fix JSONstringify issue
+    delete txForSimulation.auth_info.signer_infos[0].mode_info.multi;
+
+    // simulate
+    const simulatedResult = await rest.tx.simulate(sdk, {
+      tx: txForSimulation,
+      tx_bytes: txBuilder.txBytes(),
+    });
+    console.log('simulatedResult', simulatedResult);
+
+    // estimate fee
+    const simulatedGasUsed = simulatedResult.data.gas_info?.gas_used;
+    // This margin prevents insufficient fee due to data size difference between simulated tx and actual tx.
+    const simulatedGasUsedWithMarginNumber = simulatedGasUsed
+      ? parseInt(simulatedGasUsed) * 1.1
+      : 200000;
+    const simulatedGasUsedWithMargin = simulatedGasUsedWithMarginNumber.toFixed(0);
+    // minimumGasPrice depends on Node's config(`~/.jpyx/config/app.toml` minimum-gas-prices).
+    const simulatedFeeWithMarginNumber =
+      parseInt(simulatedGasUsedWithMargin) *
+      parseFloat(minimumGasPrice.amount ? minimumGasPrice.amount : '0');
+    const simulatedFeeWithMargin = Math.ceil(simulatedFeeWithMarginNumber).toFixed(0);
+    console.log({
+      simulatedGasUsed,
+      simulatedGasUsedWithMargin,
+      simulatedFeeWithMarginNumber,
+      simulatedFeeWithMargin,
+    });
+
+    return {
+      simulatedResultData: simulatedResult.data,
+      minimumGasPrice,
+      estimatedGasUsedWithMargin: {
+        denom: minimumGasPrice.denom,
+        amount: simulatedGasUsedWithMargin,
+      },
+      estimatedFeeWithMargin: {
+        denom: minimumGasPrice.denom,
+        amount: simulatedFeeWithMargin,
+      },
+    };
+  }
+
+  async announceTx(txBuilder: cosmosclient.TxBuilder): Promise<InlineResponse20075> {
+    const sdk = await this.cosmosSDK.sdk().then((sdk) => sdk.rest);
+
+    // broadcast tx
+    const result = await rest.tx.broadcastTx(sdk, {
+      tx_bytes: txBuilder.txBytes(),
+      mode: rest.tx.BroadcastTxMode.Block,
+    });
+
+    // check broadcast tx error
+    if (result.data.tx_response?.code !== 0) {
+      throw Error(result.data.tx_response?.raw_log);
+    }
+
+    return result.data;
+  }
+}

--- a/projects/main/src/app/pages/cosmos/bank/send/send.component.html
+++ b/projects/main/src/app/pages/cosmos/bank/send/send.component.html
@@ -2,5 +2,6 @@
   [key]="key$ | async"
   [coins]="coins$ | async"
   [amount]="amount$ | async"
+  [minimumGasPrices]="minimumGasPrices"
   (appSubmit)="onSubmit($event)"
 ></view-send>

--- a/projects/main/src/app/pages/cosmos/bank/send/send.component.ts
+++ b/projects/main/src/app/pages/cosmos/bank/send/send.component.ts
@@ -5,6 +5,7 @@ import { KeyService } from '../../../../models/keys/key.service';
 import { KeyStoreService } from '../../../../models/keys/key.store.service';
 import { SendOnSubmitEvent } from '../../../../views/cosmos/bank/send/send.component';
 import { Component, OnInit } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { cosmosclient, proto, rest } from '@cosmos-client/core';
 import { combineLatest, Observable } from 'rxjs';
 import { map, mergeMap, filter, tap } from 'rxjs/operators';
@@ -24,6 +25,7 @@ export class SendComponent implements OnInit {
     private readonly key: KeyService,
     private readonly keyStore: KeyStoreService,
     private readonly bankApplication: BankApplicationService,
+    private readonly snackBar: MatSnackBar,
   ) {
     this.key$ = this.keyStore.currentKey$;
 
@@ -52,6 +54,12 @@ export class SendComponent implements OnInit {
   ngOnInit(): void {}
 
   async onSubmit($event: SendOnSubmitEvent) {
+    if ($event.amount.length === 0) {
+      this.snackBar.open('Invalid coins', undefined, {
+        duration: 6000,
+      });
+      return;
+    }
     await this.bankApplication.send($event.key, $event.toAddress, $event.amount, $event.privateKey);
   }
 }

--- a/projects/main/src/app/pages/cosmos/bank/send/send.component.ts
+++ b/projects/main/src/app/pages/cosmos/bank/send/send.component.ts
@@ -7,8 +7,9 @@ import { SendOnSubmitEvent } from '../../../../views/cosmos/bank/send/send.compo
 import { Component, OnInit } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { cosmosclient, proto, rest } from '@cosmos-client/core';
+import { ConfigService } from 'projects/main/src/app/models/config.service';
 import { combineLatest, Observable } from 'rxjs';
-import { map, mergeMap, filter, tap } from 'rxjs/operators';
+import { map, mergeMap, filter } from 'rxjs/operators';
 
 @Component({
   selector: 'app-send',
@@ -19,6 +20,7 @@ export class SendComponent implements OnInit {
   key$: Observable<Key | undefined>;
   coins$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
   amount$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
+  minimumGasPrices: proto.cosmos.base.v1beta1.ICoin[];
 
   constructor(
     private readonly cosmosSDK: CosmosSDKService,
@@ -26,6 +28,7 @@ export class SendComponent implements OnInit {
     private readonly keyStore: KeyStoreService,
     private readonly bankApplication: BankApplicationService,
     private readonly snackBar: MatSnackBar,
+    private readonly configS: ConfigService,
   ) {
     this.key$ = this.keyStore.currentKey$;
 
@@ -49,6 +52,8 @@ export class SendComponent implements OnInit {
         })),
       ),
     );
+
+    this.minimumGasPrices = this.configS.config.minimumGasPrices;
   }
 
   ngOnInit(): void {}
@@ -60,6 +65,12 @@ export class SendComponent implements OnInit {
       });
       return;
     }
-    await this.bankApplication.send($event.key, $event.toAddress, $event.amount, $event.privateKey);
+    await this.bankApplication.send(
+      $event.key,
+      $event.toAddress,
+      $event.amount,
+      $event.minimumGasPrice,
+      $event.privateKey,
+    );
   }
 }

--- a/projects/main/src/app/views/cosmos/bank/send/send.component.html
+++ b/projects/main/src/app/views/cosmos/bank/send/send.component.html
@@ -7,7 +7,8 @@
 </ng-template>
 <ng-template #exist>
   <mat-list>
-    <h3 matSubheader>Send</h3>
+    <h3>Bank-Send</h3>
+    <h4>Balances</h4>
     <mat-divider></mat-divider>
     <ng-container *ngFor="let coin of coins">
       <mat-list-item>
@@ -18,6 +19,8 @@
       <mat-divider></mat-divider>
     </ng-container>
   </mat-list>
+
+  <h4 class="pt-6 pb-0">Sending Form</h4>
   <form #formRef="ngForm" (submit)="onSubmit(toAddressRef.value, privateKeyRef.value, minimumGasPriceRef.value)">
     <mat-form-field class="w-full">
       <mat-label>To address</mat-label>
@@ -51,6 +54,7 @@
       </div>
     </ng-container>
 
+    <h4 class="pt-3">Gas Settings</h4>
     <div class="flex flex-row content-content items-end">
       <mat-form-field class="flex-auto">
         <mat-label>Minimum Gas Denom</mat-label>
@@ -78,7 +82,16 @@
         />
       </mat-form-field>
     </div>
+    <mat-slider class="w-full"
+    [max]="1"
+    [min]="0"
+    [step]="0.015"
+    [(ngModel)]="selectedGasPrice && selectedGasPrice.amount"
+    name="minimum-gas-price-slider"
+  >
+  </mat-slider>
 
+    <h4 class="pt-3">Signer</h4>
     <mat-form-field class="w-full">
       <mat-label>ID</mat-label>
       <input

--- a/projects/main/src/app/views/cosmos/bank/send/send.component.html
+++ b/projects/main/src/app/views/cosmos/bank/send/send.component.html
@@ -18,7 +18,7 @@
       <mat-divider></mat-divider>
     </ng-container>
   </mat-list>
-  <form #formRef="ngForm" (submit)="onSubmit(toAddressRef.value, privateKeyRef.value)">
+  <form #formRef="ngForm" (submit)="onSubmit(toAddressRef.value, privateKeyRef.value, minimumGasPriceRef.value)">
     <mat-form-field class="w-full">
       <mat-label>To address</mat-label>
       <input #toAddressRef ngModel name="to-address" matInput required />
@@ -50,6 +50,34 @@
         </mat-form-field>
       </div>
     </ng-container>
+
+    <div class="flex flex-row content-center items-center">
+      <mat-form-field class="flex-auto">
+        <mat-label>Minimum Gas Denom</mat-label>
+        <mat-select
+          [(ngModel)]="selectedGasPrice && selectedGasPrice.denom"
+          name="minimum-gas-denom"
+          required
+          (valueChange)="onMinimumGasDenomChanged($event)"
+        >
+          <mat-option *ngFor="let minimumGasPrice of minimumGasPrices" [value]="minimumGasPrice.denom">
+            {{ minimumGasPrice.denom }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field class="flex-auto">
+        <mat-label>Minimum Gas Price</mat-label>
+        <input
+          [(ngModel)]="selectedGasPrice && selectedGasPrice.amount"
+          #minimumGasPriceRef
+          name="minimum-gas-price"
+          matInput
+          type="number"
+          [min]="0"
+          required
+        />
+      </mat-form-field>
+    </div>
 
     <mat-form-field class="w-full">
       <mat-label>ID</mat-label>

--- a/projects/main/src/app/views/cosmos/bank/send/send.component.html
+++ b/projects/main/src/app/views/cosmos/bank/send/send.component.html
@@ -51,7 +51,7 @@
       </div>
     </ng-container>
 
-    <div class="flex flex-row content-center items-center">
+    <div class="flex flex-row content-content items-end">
       <mat-form-field class="flex-auto">
         <mat-label>Minimum Gas Denom</mat-label>
         <mat-select

--- a/projects/main/src/app/views/cosmos/bank/send/send.component.ts
+++ b/projects/main/src/app/views/cosmos/bank/send/send.component.ts
@@ -6,6 +6,7 @@ export type SendOnSubmitEvent = {
   key: Key;
   toAddress: string;
   amount: proto.cosmos.base.v1beta1.ICoin[];
+  minimumGasPrice: proto.cosmos.base.v1beta1.ICoin;
   privateKey: string;
 };
 
@@ -24,19 +25,34 @@ export class SendComponent implements OnInit {
   @Input()
   amount?: proto.cosmos.base.v1beta1.ICoin[] | null;
 
+  @Input()
+  minimumGasPrices?: proto.cosmos.base.v1beta1.ICoin[];
+
   @Output()
   appSubmit: EventEmitter<SendOnSubmitEvent>;
+
+  selectedGasPrice?: proto.cosmos.base.v1beta1.ICoin;
 
   constructor() {
     this.appSubmit = new EventEmitter();
   }
 
+  ngOnChanges(): void {
+    if (this.minimumGasPrices && this.minimumGasPrices.length > 0) {
+      this.selectedGasPrice = this.minimumGasPrices[0];
+    }
+  }
+
   ngOnInit(): void {}
 
-  onSubmit(toAddress: string, privateKey: string) {
+  onSubmit(toAddress: string, privateKey: string, minimumGasPrice: string) {
     if (!this.amount) {
       return;
     }
+    if (this.selectedGasPrice === undefined) {
+      return;
+    }
+    this.selectedGasPrice.amount = minimumGasPrice.toString();
     this.appSubmit.emit({
       key: this.key!,
       toAddress,
@@ -48,7 +64,14 @@ export class SendComponent implements OnInit {
           denom: coin.denom,
           amount: coin.amount?.toString(),
         })),
+      minimumGasPrice: this.selectedGasPrice,
       privateKey,
     });
+  }
+
+  onMinimumGasDenomChanged(denom: string): void {
+    this.selectedGasPrice = this.minimumGasPrices?.find(
+      (minimumGasPrice) => minimumGasPrice.denom === denom,
+    );
   }
 }

--- a/projects/main/src/app/views/cosmos/bank/send/send.component.ts
+++ b/projects/main/src/app/views/cosmos/bank/send/send.component.ts
@@ -74,4 +74,10 @@ export class SendComponent implements OnInit {
       (minimumGasPrice) => minimumGasPrice.denom === denom,
     );
   }
+
+  onMinimumGasAmountSliderChanged(amount: string): void {
+    if (this.selectedGasPrice) {
+      this.selectedGasPrice.amount = amount;
+    }
+  }
 }

--- a/projects/main/src/app/views/cosmos/tx-fee-confirm-dialog/tx-fee-confirm-dialog.component.html
+++ b/projects/main/src/app/views/cosmos/tx-fee-confirm-dialog/tx-fee-confirm-dialog.component.html
@@ -1,0 +1,8 @@
+<mat-dialog-content>
+  <div>
+    The tx fee will be {{data.fee.amount}}{{data.fee.denom}}.
+  </div>
+  <div>Are you sure you want to send the tx with the fee?</div>
+  <button mat-flat-button class="w-2/5" color="primary" (click)="okToSendTx()">OK</button>
+  <button mat-flat-button class="w-2/5" (click)="cancelToSendTx()">Cancel</button>
+</mat-dialog-content>

--- a/projects/main/src/app/views/cosmos/tx-fee-confirm-dialog/tx-fee-confirm-dialog.component.ts
+++ b/projects/main/src/app/views/cosmos/tx-fee-confirm-dialog/tx-fee-confirm-dialog.component.ts
@@ -21,13 +21,11 @@ export class TxFeeConfirmDialogComponent implements OnInit {
 
   okToSendTx(): void {
     this.data.isConfirmed = true;
-    console.log(this.data);
     this.dialogRef.close(this.data);
   }
 
   cancelToSendTx(): void {
     this.data.isConfirmed = false;
-    console.log(this.data);
     this.dialogRef.close(this.data);
   }
 }

--- a/projects/main/src/app/views/cosmos/tx-fee-confirm-dialog/tx-fee-confirm-dialog.component.ts
+++ b/projects/main/src/app/views/cosmos/tx-fee-confirm-dialog/tx-fee-confirm-dialog.component.ts
@@ -1,0 +1,33 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { proto } from '@cosmos-client/core';
+
+@Component({
+  selector: 'app-view-tx-fee-confirm-dialog',
+  templateUrl: './tx-fee-confirm-dialog.component.html',
+  styleUrls: ['./tx-fee-confirm-dialog.component.css'],
+})
+export class TxFeeConfirmDialogComponent implements OnInit {
+  constructor(
+    @Inject(MAT_DIALOG_DATA)
+    public readonly data: {
+      fee: proto.cosmos.base.v1beta1.ICoin;
+      isConfirmed: boolean;
+    },
+    private readonly dialogRef: MatDialogRef<TxFeeConfirmDialogComponent>,
+  ) {}
+
+  ngOnInit(): void {}
+
+  okToSendTx(): void {
+    this.data.isConfirmed = true;
+    console.log(this.data);
+    this.dialogRef.close(this.data);
+  }
+
+  cancelToSendTx(): void {
+    this.data.isConfirmed = false;
+    console.log(this.data);
+    this.dialogRef.close(this.data);
+  }
+}

--- a/projects/main/src/app/views/cosmos/tx-fee-confirm-dialog/tx-fee-confirm-dialog.module.ts
+++ b/projects/main/src/app/views/cosmos/tx-fee-confirm-dialog/tx-fee-confirm-dialog.module.ts
@@ -1,0 +1,11 @@
+import { MaterialModule } from '../../material.module';
+import { TxFeeConfirmDialogComponent } from './tx-fee-confirm-dialog.component';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+@NgModule({
+  declarations: [TxFeeConfirmDialogComponent],
+  imports: [CommonModule, MaterialModule],
+  exports: [TxFeeConfirmDialogComponent],
+})
+export class TxFeeConfirmDialogModule {}

--- a/projects/main/src/app/views/keys/key-select-dialog/key-select-dialog.component.html
+++ b/projects/main/src/app/views/keys/key-select-dialog/key-select-dialog.component.html
@@ -1,12 +1,14 @@
-<mat-nav-list>
-  <ng-template ngFor let-key [ngForOf]="data.keys">
-    <mat-list-item (click)="onClickKey(key)">
-      <mat-icon matListIcon [ngStyle]="{ color: getColorCode(key) }"> circle </mat-icon>
-      <span>{{ key.id }}</span>
-      <span class="flex-auto"></span>
-      <ng-container *ngIf="data.currentKeyID === key.id">
-        <mat-icon color="primary">check</mat-icon>
-      </ng-container>
-    </mat-list-item>
-  </ng-template>
-</mat-nav-list>
+<mat-dialog-content>
+  <mat-nav-list>
+    <ng-template ngFor let-key [ngForOf]="data.keys">
+      <mat-list-item (click)="onClickKey(key)">
+        <mat-icon matListIcon [ngStyle]="{ color: getColorCode(key) }"> circle </mat-icon>
+        <span>{{ key.id }}</span>
+        <span class="flex-auto"></span>
+        <ng-container *ngIf="data.currentKeyID === key.id">
+          <mat-icon color="primary">check</mat-icon>
+        </ng-container>
+      </mat-list-item>
+    </ng-template>
+  </mat-nav-list>
+</mat-dialog-content>

--- a/projects/main/src/app/views/material.module.ts
+++ b/projects/main/src/app/views/material.module.ts
@@ -15,6 +15,7 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatSliderModule } from '@angular/material/slider';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -41,6 +42,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
     MatToolbarModule,
     MatTableModule,
     ClipboardModule,
+    MatSliderModule,
   ],
 })
 export class MaterialModule {}

--- a/projects/main/src/app/views/material.module.ts
+++ b/projects/main/src/app/views/material.module.ts
@@ -1,8 +1,9 @@
-import { NgModule } from '@angular/core';
+import { ClipboardModule } from '@angular/cdk/clipboard';
 import { CommonModule } from '@angular/common';
-
+import { NgModule } from '@angular/core';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatDividerModule } from '@angular/material/divider';
@@ -15,10 +16,8 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatCardModule } from '@angular/material/card';
 import { MatTableModule } from '@angular/material/table';
-import { ClipboardModule } from '@angular/cdk/clipboard';
+import { MatToolbarModule } from '@angular/material/toolbar';
 
 @NgModule({
   declarations: [],
@@ -44,4 +43,4 @@ import { ClipboardModule } from '@angular/cdk/clipboard';
     ClipboardModule,
   ],
 })
-export class MaterialModule { }
+export class MaterialModule {}


### PR DESCRIPTION
@KimuraYu45z 
トランザクションのアナウンスの前に、simulateのAPIを叩くような意図で、このプルリクのような形で実装してみたのですが、以下エラーを解決できない状態で詰まっています。いったんこのプルリクで現状の記録を残しておきます。

```
./projects/main/src/app/models/cosmos/bank.service.ts:3:0-92 - Error: Module not found: Error: Package path ./esm/openapi/api is not exported from package /home/yasunori_matsuoka/src/github.com/lcnem/telescope/node_modules/@cosmos-client/core (see exports field in /home/yasunori_matsuoka/src/github.com/lcnem/telescope/node_modules/@cosmos-client/core/package.json)
```
